### PR TITLE
feat: invalid photo format action

### DIFF
--- a/src/Models/Enums/CopyInvalidFormatAction.cs
+++ b/src/Models/Enums/CopyInvalidFormatAction.cs
@@ -1,0 +1,9 @@
+namespace PhotoCli.Models.Enums;
+
+public enum CopyInvalidFormatAction : byte
+{
+	Continue = 0,
+	PreventProcess = 1,
+	DontCopyToOutput = 2,
+	InSubFolder = 3,
+}

--- a/src/Models/Enums/ExitCode.cs
+++ b/src/Models/Enums/ExitCode.cs
@@ -30,6 +30,7 @@ public enum ExitCode
 	PhotosWithNoDatePreventedProcess = 30,
 	PhotosWithNoCoordinatePreventedProcess = 31,
 	PhotosWithNoCoordinateAndNoDatePreventedProcess = 32,
+	PhotosWithInvalidFileFormatPreventedProcess = 33,
 
 	// Settings
 	PropertyNotFound = 40,

--- a/src/Models/Enums/InfoInvalidFormatAction.cs
+++ b/src/Models/Enums/InfoInvalidFormatAction.cs
@@ -1,0 +1,7 @@
+namespace PhotoCli.Models.Enums;
+
+public enum InfoInvalidFormatAction : byte
+{
+	Continue = 0,
+	PreventProcess = 1,
+}

--- a/src/Models/Photo.cs
+++ b/src/Models/Photo.cs
@@ -4,7 +4,7 @@ namespace PhotoCli.Models;
 
 public class Photo
 {
-	public Photo(IFileSystemInfo fileInfo, ExifData photoExifData, string targetRelativeDirectoryPath)
+	public Photo(IFileSystemInfo fileInfo, ExifData? photoExifData, string targetRelativeDirectoryPath)
 	{
 		FilePath = fileInfo.FullName;
 		if (!fileInfo.Extension.StartsWith("."))
@@ -20,23 +20,25 @@ public class Photo
 
 	public string FilePath { get; }
 
-	public ExifData PhotoExifData { get; }
-	public DateTime? PhotoTakenDateTime => PhotoExifData.TakenDate;
-	public string? ReverseGeocodeFormatted => PhotoExifData.ReverseGeocodeFormatted;
+	public ExifData? PhotoExifData { get; }
+
+	public bool HasExifData => PhotoExifData != null;
+	public DateTime? PhotoTakenDateTime => PhotoExifData?.TakenDate;
+	public string? ReverseGeocodeFormatted => PhotoExifData?.ReverseGeocodeFormatted;
 
 	public string TargetRelativeDirectoryPath { get; set; }
 
 	public string? NewName { get; set; }
 
 	public bool HasPhotoTakenDateTime => PhotoTakenDateTime.HasValue;
-	public bool HasCoordinate => PhotoExifData.Coordinate != null;
-	public bool HasReverseGeocode => PhotoExifData.ReverseGeocodes != null && PhotoExifData.ReverseGeocodes.Any();
-	public List<string>? ReverseGeocodes => PhotoExifData.ReverseGeocodes?.ToList() ?? null;
+	public bool HasCoordinate => PhotoExifData?.Coordinate != null;
+	public bool HasReverseGeocode => PhotoExifData?.ReverseGeocodes != null && PhotoExifData.ReverseGeocodes.Any();
+	public List<string>? ReverseGeocodes => PhotoExifData?.ReverseGeocodes?.ToList() ?? null;
 
-	public int ReverseGeocodeCount => PhotoExifData.ReverseGeocodes?.Count() ?? 0;
+	public int ReverseGeocodeCount => PhotoExifData?.ReverseGeocodes?.Count() ?? 0;
 	private string GetFileNameForOutput => NewName ?? FileNameWithoutExtension;
 
-	public string Sha1Hash { get; set; }
+	public string? Sha1Hash { get; set; }
 
 	public string DestinationPath(string outputFolder)
 	{

--- a/src/Models/Statistics.cs
+++ b/src/Models/Statistics.cs
@@ -16,4 +16,7 @@ public record Statistics
 	public int HasCoordinateCount => PhotoThatHasTakenDateAndCoordinate + PhotoThatHasCoordinateButNoTakenDate;
 
 	public List<string> FileIoErrors { get; } = new();
+
+	public int InvalidFormatError { get; set; }
+	public int InternalError { get; set; }
 }

--- a/src/Options/CopyOptions.cs
+++ b/src/Options/CopyOptions.cs
@@ -7,12 +7,11 @@ public class CopyOptions : IReverseGeocodeOptions
 {
 	// Notes: Constructor parameters and properties should be in same order for Immutable Options Type in CommandLineParser.
 	// ref: https://github.com/commandlineparser/commandline/wiki/Immutable-Options-Type
-
 	public CopyOptions(
 		// Required
-		string outputPath, NamingStyle namingStyle, FolderProcessType folderProcessType, NumberNamingTextStyle numberNamingTextStyle, CopyNoPhotoTakenDateAction noPhotoTakenDateAction,
-		CopyNoCoordinateAction noCoordinateAction,
+		string outputPath, NamingStyle namingStyle, FolderProcessType folderProcessType, NumberNamingTextStyle numberNamingTextStyle,
 		// Optional
+		CopyInvalidFormatAction invalidFileFormatAction, CopyNoPhotoTakenDateAction noPhotoTakenDateAction, CopyNoCoordinateAction noCoordinateAction,
 		string? inputPath = null, bool isDryRun = false, GroupByFolderType? groupByFolderType = null, FolderAppendType? folderAppendType = null,
 		FolderAppendLocationType? folderAppendLocationType = null, bool verify = false,
 		// ReverseGeocode - Shared
@@ -25,10 +24,11 @@ public class CopyOptions : IReverseGeocodeOptions
 		NamingStyle = namingStyle;
 		FolderProcessType = folderProcessType;
 		NumberNamingTextStyle = numberNamingTextStyle;
-		NoPhotoTakenDateAction = noPhotoTakenDateAction;
-		NoCoordinateAction = noCoordinateAction;
 
 		// Optional
+		InvalidFileFormatAction = invalidFileFormatAction;
+		NoPhotoTakenDateAction = noPhotoTakenDateAction;
+		NoCoordinateAction = noCoordinateAction;
 		InputPath = inputPath;
 		IsDryRun = isDryRun;
 		GroupByFolderType = groupByFolderType;
@@ -61,6 +61,9 @@ public class CopyOptions : IReverseGeocodeOptions
 
 	[Option(OptionNames.NumberNamingTextStyleOptionNameShort, OptionNames.NumberNamingTextStyleOptionNameLong, HelpText = HelpTexts.NumberNamingTextStyle)]
 	public NumberNamingTextStyle NumberNamingTextStyle { get; }
+
+	[Option(OptionNames.CopyInvalidFormatActionOptionNameShort, OptionNames.CopyInvalidFormatActionOptionNameLong, HelpText = HelpTexts.CopyInvalidFormatAction)]
+	public CopyInvalidFormatAction InvalidFileFormatAction { get; }
 
 	[Option(OptionNames.CopyNoPhotoDateTimeTakenActionOptionNameShort, OptionNames.CopyNoPhotoDateTimeTakenActionOptionNameLong, HelpText = HelpTexts.CopyNoPhotoTakenDateAction)]
 	public CopyNoPhotoTakenDateAction NoPhotoTakenDateAction { get; }

--- a/src/Options/HelpTexts.cs
+++ b/src/Options/HelpTexts.cs
@@ -4,29 +4,35 @@ public static class HelpTexts
 {
 	#region Copy
 
-	public const string NamingStyle =
-		"(MUST) Naming strategy of newly copied file name. ( Numeric: 1, Day: 2, DateTimeWithMinutes: 3, DateTimeWithSeconds: 4, Address: 5, DayAddress: 6, DateTimeWithMinutesAddress: 7, DateTimeWithSecondsAddress: 8, AddressDay: 9, AddressDateTimeWithMinutes: 10, AddressDateTimeWithSeconds: 11 )";
+	public const string NamingStyle = "(MUST) Naming strategy of newly copied file name. " +
+	                                  "( Numeric: 1, Day: 2, DateTimeWithMinutes: 3, DateTimeWithSeconds: 4, Address: 5, DayAddress: 6, DateTimeWithMinutesAddress: 7, " +
+	                                  "DateTimeWithSecondsAddress: 8, " + "AddressDay: 9, AddressDateTimeWithMinutes: 10, AddressDateTimeWithSeconds: 11 )";
 
 	public const string FolderProcessType = "(MUST) Reading photos strategy from input folder. ( Single: 1, SubFoldersPreserveFolderHierarchy: 2, FlattenAllSubFolders: 3 )";
 
-	public const string NumberNamingTextStyle =
-		"(MUST) Number naming strategy when using `NamingStyle` as `Numeric` or using to numbering the possible same names. ( AllNamesAreSameLength: 1, PaddingZeroCharacter: 2, OnlySequentialNumbers: 3 )";
+	public const string NumberNamingTextStyle = "(MUST) Number naming strategy when using `NamingStyle` as `Numeric` or using to numbering the possible same names. " +
+	                                            "( AllNamesAreSameLength: 1, PaddingZeroCharacter: 2, OnlySequentialNumbers: 3 )";
 
-	public const string CopyNoPhotoTakenDateAction =
-		"(MUST) Action to do when a photo with a no taken date. ( Continue: 0, PreventProcess: 1, DontCopyToOutput: 2, InSubFolder: 3, AppendToEndOrderByFileName: 4, InsertToBeginningOrderByFileName: 5 )";
+	public const string CopyNoPhotoTakenDateAction = "(Optional) Action to do when a photo with a no taken date. " +
+	                                                 "( Continue: 0 [default], PreventProcess: 1, DontCopyToOutput: 2, InSubFolder: 3, " +
+	                                                 "AppendToEndOrderByFileName: 4, InsertToBeginningOrderByFileName: 5 )";
 
-	public const string CopyNoCoordinateAction =
-		"(MUST) Action to do when a photo with a no coordinate. ( Continue: 0, PreventProcess: 1, DontCopyToOutput: 2, InSubFolder: 3 )";
+	public const string CopyNoCoordinateAction = "(Optional) Action to do when a photo with a no coordinate. ( Continue: 0 [default], PreventProcess: 1, DontCopyToOutput: 2, InSubFolder: 3 )";
+
+	public const string CopyInvalidFormatAction = "(Optional) Action to do when a photo format is invalid. " +
+	                                              "( Continue: 0 [default], PreventProcess: 1, DontCopyToOutput: 2, InSubFolder: 3 )";
 
 	public const string IsDryRun = "(Optional) Simulate the same process without writing to the output folder. (no extra parameter needed)";
 
-	public const string GroupByFolderType =
-		"(Optional) Strategy to group photos into folders. [Can't use with `FolderProcessType` is `SubFoldersPreserveFolderHierarchy`] ( YearMonthDay: 1, YearMonth: 2, Year: 3, AddressFlat: 4, AddressHierarchy: 5 )";
+	public const string GroupByFolderType = "(Optional) Strategy to group photos into folders. [Can't use with `FolderProcessType` is `SubFoldersPreserveFolderHierarchy`] " +
+	                                        "( YearMonthDay: 1, YearMonth: 2, Year: 3, AddressFlat: 4, AddressHierarchy: 5 )";
 
-	public const string FolderAppendType =
-		"(Optional) Appending name strategy to folder names cloned from source folder hierarchy. [Can be with `FolderProcessType` is `SubFoldersPreserveFolderHierarchy`] ( FirstYearMonthDay: 1, FirstYearMonth: 2, FirstYear: 3, DayRange: 4, MatchingMinimumAddress: 5 )";
+	public const string FolderAppendType = "(Optional) Appending name strategy to folder names cloned from source folder hierarchy. " +
+	                                       "[Can be with `FolderProcessType` is `SubFoldersPreserveFolderHierarchy`] " +
+	                                       "( FirstYearMonthDay: 1, FirstYearMonth: 2, FirstYear: 3, DayRange: 4, MatchingMinimumAddress: 5 )";
 
-	public const string FolderAppendLocationType = "(Optional) Append location for `FolderAppendType`. [Can be use with `FolderProcessType` is `SubFoldersPreserveFolderHierarchy`] ( Prefix: 1, Suffix: 2 )";
+	public const string FolderAppendLocationType = "(Optional) Append location for `FolderAppendType`. " +
+	                                               "[Can be use with `FolderProcessType` is `SubFoldersPreserveFolderHierarchy`] ( Prefix: 1, Suffix: 2 )";
 
 	public const string Verify = "(Optional) Verify that all photo files copied succesfully by comparing file hashes. (no extra parameter needed)";
 
@@ -42,9 +48,11 @@ public static class HelpTexts
 
 	public const string AllFolders = "(Optional) Read & list all photos in all subfolders (no extra parameter needed)";
 
-	public const string InfoNoPhotoTakenDateAction = "(Optional) Action to do when a photo with a no taken date. ( Continue: 0, PreventProcess: 1 )";
+	public const string InfoNoPhotoTakenDateAction = "(Optional) Action to do when a photo with a no taken date. ( Continue: 0 [default], PreventProcess: 1 )";
 
-	public const string InfoNoCoordinateAction = "(Optional) Action to do when a photo with a no coordinate. ( Continue: 0, PreventProcess: 1 )";
+	public const string InfoNoCoordinateAction = "(Optional) Action to do when a photo with a no coordinate. ( Continue: 0 [default], PreventProcess: 1 )";
+
+	public const string InfoInvalidFormatAction = "(Optional) Action to do when a photo format is invalid. ( Continue: 0 [default], PreventProcess: 1 )";
 
 	#endregion
 
@@ -60,36 +68,37 @@ public static class HelpTexts
 
 	public const string InputPath = "(Default current executing folder) File system path to read & copy photos from. ( there will be no modification on the input path )";
 
-	public const string OutputPathCopy = "(MUST) File system path to create new organized folder. A new folder hierarchy will be created on that location with new file names. (will create folder if not exist)";
+	public const string OutputPathCopy = "(MUST) File system path to create new organized folder. " +
+	                                     "A new folder hierarchy will be created on that location with new file names. (will create folder if not exist)";
 
 	public const string OutputPathInfo = "(MUST) File system path to write report file.";
 
-	public const string ReverseGeocodeProvider =
-		"(Optional) Third-party provider to resolve photo taken address by photo's coordinates. ( Disabled: 0 [default], BigDataCloud: 1, OpenStreetMapFoundation: 2, GoogleMaps: 3, LocationIq: 5 )";
+	public const string ReverseGeocodeProvider = "(Optional) Third-party provider to resolve photo taken address by photo's coordinates. " +
+	                                             "( Disabled: 0 [default], BigDataCloud: 1, OpenStreetMapFoundation: 2, GoogleMaps: 3, LocationIq: 5 )";
 
-	public const string BigDataCloudApiKey =
-		"(Optional) API key needed to use BigDataCloud. https://www.bigdatacloud.com/geocoding-apis/reverse-geocode-to-city-api/ (Instead of using this option, environment name: " +
-		ApiKeyStore.BigDataCloudApiKeyEnvironmentKey + " can be used or `BigDataCloudApiKey` key can be set via settings command. )";
+	public const string BigDataCloudApiKey = "(Optional) API key needed to use BigDataCloud. https://www.bigdatacloud.com/geocoding-apis/reverse-geocode-to-city-api/ " +
+	                                         "(Instead of using this option, environment name: " + ApiKeyStore.BigDataCloudApiKeyEnvironmentKey + " can be used or " +
+	                                         "`BigDataCloudApiKey` key can be set via settings command. )";
 
-	public const string BigDataCloudAdminLevels =
-		"(Optional) Admin levels separated with space. ( To see which level correspond to which address level, you may use `photo-cli address` to see the full response returned from BigDataCloud. )";
+	public const string BigDataCloudAdminLevels = "(Optional) Admin levels separated with space. " +
+	                                              "( To see which level correspond to which address level, you may use `photo-cli address` to see the full response returned from BigDataCloud. )";
 
-	public const string GoogleMapsAddressTypes =
-		"(Optional) GoogleMaps address types separated with space. ( To see which level correspond to which address level, you may use `photo-cli address` to see the full response returned from GoogleMaps. )";
+	public const string GoogleMapsAddressTypes = "(Optional) GoogleMaps address types separated with space. " +
+	                                             "( To see which level correspond to which address level, you may use `photo-cli address` to see the full response returned from GoogleMaps. )";
 
 	public const string GoogleMapsApiKey = "(Optional) API key needed to use GoogleMaps. https://developers.google.com/maps/documentation/geocoding/overview/ (Instead of using this option, environment name: " +
 	                                       ApiKeyStore.GoogleMapsApiKeyEnvironmentKey + " can be used or `GoogleMapsApiKey` key can be set via settings command. )";
 
-	public const string OpenStreetMapProperties =
-		"(Optional) OpenStreetMap properties separated with space. ( To see which level correspond to which address level, you may use `photo-cli address` to see the full response returned from OpenStreetMap provider. )";
+	public const string OpenStreetMapProperties = "(Optional) OpenStreetMap properties separated with space. " +
+	                                              "( To see which level correspond to which address level, you may use `photo-cli address` to see the full response returned from OpenStreetMap provider. )";
 
 	public const string LocationIqApiKey = "(Optional) API key needed to use LocationIq. https://locationiq.com/docs/ (Instead of using this option, environment name: " +
 	                                       ApiKeyStore.LocationIqApiKeyEnvironmentKey + " can be used or `LocationIqApiKey` key can be set via settings command. )";
 
 	public const string HasPaidLicense = "(Optional) Bypass the free rate limit if you have paid license. ( For LocationIq. )";
 
-	public const string Language =
-		"(Optional) Language/culture value to get localized address result for BigDataCloud ( https://www.bigdatacloud.com/supported-languages/ ) and GoogleMaps (https://developers.google.com/maps/faq#languagesupport ). ";
+	public const string Language = "(Optional) Language/culture value to get localized address result for BigDataCloud " +
+	                               "( https://www.bigdatacloud.com/supported-languages/ ) and GoogleMaps (https://developers.google.com/maps/faq#languagesupport ). ";
 
 	#endregion
 }

--- a/src/Options/InfoOptions.cs
+++ b/src/Options/InfoOptions.cs
@@ -11,8 +11,9 @@ public class InfoOptions : IReverseGeocodeOptions
 		// Required
 		string outputPath,
 		// Optional
-		string? inputPath = null, bool allFolders = false, InfoNoPhotoTakenDateAction noPhotoTakenDateAction = InfoNoPhotoTakenDateAction.Continue,
-		InfoNoCoordinateAction noCoordinateAction = InfoNoCoordinateAction.Continue,
+		string? inputPath = null, bool allFolders = false,
+		InfoInvalidFormatAction invalidFileFormatAction = InfoInvalidFormatAction.Continue,
+		InfoNoPhotoTakenDateAction noPhotoTakenDateAction = InfoNoPhotoTakenDateAction.Continue, InfoNoCoordinateAction noCoordinateAction = InfoNoCoordinateAction.Continue,
 		// ReverseGeocode - Shared
 		ReverseGeocodeProvider reverseGeoCodeProvider = ReverseGeocodeProvider.Disabled, string? bigDataCloudApiKey = null, IEnumerable<int>? bigDataCloudAdminLevels = null,
 		IEnumerable<string>? googleMapsAddressTypes = null,
@@ -25,6 +26,7 @@ public class InfoOptions : IReverseGeocodeOptions
 		// Optional
 		InputPath = inputPath;
 		AllFolders = allFolders;
+		InvalidFileFormatAction = invalidFileFormatAction;
 		NoPhotoTakenDateAction = noPhotoTakenDateAction;
 		NoCoordinateAction = noCoordinateAction;
 
@@ -54,6 +56,9 @@ public class InfoOptions : IReverseGeocodeOptions
 
 	[Option(OptionNames.AllFoldersOptionNameShort, OptionNames.AllFoldersOptionNameLong, HelpText = HelpTexts.AllFolders)]
 	public bool AllFolders { get; }
+
+	[Option(OptionNames.InfoInvalidFormatActionOptionNameShort, OptionNames.InfoInvalidFormatActionOptionNameLong, HelpText = HelpTexts.InfoInvalidFormatAction)]
+	public InfoInvalidFormatAction InvalidFileFormatAction { get; }
 
 	[Option(OptionNames.InfoNoPhotoDateTimeTakenActionOptionNameShort, OptionNames.InfoNoPhotoDateTimeTakenActionOptionNameLong, HelpText = HelpTexts.InfoNoPhotoTakenDateAction)]
 	public InfoNoPhotoTakenDateAction NoPhotoTakenDateAction { get; }

--- a/src/Options/OptionNames.cs
+++ b/src/Options/OptionNames.cs
@@ -2,6 +2,35 @@ namespace PhotoCli.Options;
 
 internal static class OptionNames
 {
+	/* Short Option Name Usages
+		a - copy, info
+		b - copy, info, address
+		c - copy, info
+		d - copy
+		e - copy, info, address
+		f - copy
+		g - copy
+		h - copy, info
+		i - copy, info, address
+		j -
+		k - settings
+		l - copy, info, address
+		m - copy, info, address
+		n - copy
+		o - copy, info
+		p - copy
+		q - copy, info, address
+		r - copy, info, address, settings
+		s - copy
+		t - copy, info, address
+		u - copy, info, address
+		v - copy, settings
+		w -
+		x - copy, info
+		y -
+		z -
+	*/
+
 	internal const string ApplicationAlias = "photo-cli";
 
 	internal const string AddressVerb = "address";
@@ -35,6 +64,9 @@ internal static class OptionNames
 	internal const char CopyNoCoordinateActionOptionNameShort = NoCoordinateActionOptionNameShort;
 	internal const string CopyNoCoordinateActionOptionNameLong = NoCoordinateActionOptionNameLong;
 
+	internal const char CopyInvalidFormatActionOptionNameShort = InvalidFormatActionOptionNameShort;
+	internal const string CopyInvalidFormatActionOptionNameLong = InvalidFormatActionOptionNameLong;
+
 	internal const char IsDryRunOptionNameShort = 'd';
 	internal const string IsDryRunOptionNameLong = "dry-run";
 
@@ -53,6 +85,9 @@ internal static class OptionNames
 
 	internal const char InfoNoCoordinateActionOptionNameShort = NoCoordinateActionOptionNameShort;
 	internal const string InfoNoCoordinateActionOptionNameLong = NoCoordinateActionOptionNameLong;
+
+	internal const char InfoInvalidFormatActionOptionNameShort = InvalidFormatActionOptionNameShort;
+	internal const string InfoInvalidFormatActionOptionNameLong = InvalidFormatActionOptionNameLong;
 
 	#endregion
 
@@ -120,6 +155,9 @@ internal static class OptionNames
 
 	private const char NoCoordinateActionOptionNameShort = 'c';
 	private const string NoCoordinateActionOptionNameLong = "no-coordinate";
+
+	private const char InvalidFormatActionOptionNameShort = 'x';
+	private const string InvalidFormatActionOptionNameLong = "invalid-format";
 
 	#endregion
 }

--- a/src/Options/ToolOptions.cs
+++ b/src/Options/ToolOptions.cs
@@ -13,6 +13,7 @@ public class ToolOptions
 	internal const string FolderAppendSeparatorDefault = "-";
 	internal const string DayRangeSeparatorDefault = "-";
 	internal const string SameNameNumberSeparatorDefault = "-";
+	internal const string PhotoFormatInvalidFolderNameDefault = "invalid-photo-format";
 	internal const string NoPhotoTakenDateFolderNameDefault = "no-photo-taken-date";
 	internal const string NoAddressFolderNameDefault = "no-address";
 	internal const string NoAddressAndPhotoTakenDateFolderNameDefault = "no-address-and-no-photo-taken-date";
@@ -34,6 +35,7 @@ public class ToolOptions
 		FolderAppendSeparator = options.FolderAppendSeparator ?? FolderAppendSeparatorDefault;
 		DayRangeSeparator = options.DayRangeSeparator ?? DayRangeSeparatorDefault;
 		SameNameNumberSeparator = options.SameNameNumberSeparator ?? SameNameNumberSeparatorDefault;
+		PhotoFormatInvalidFolderName = options.PhotoFormatInvalidFolderName ?? PhotoFormatInvalidFolderNameDefault;
 		NoPhotoTakenDateFolderName = options.NoPhotoTakenDateFolderName ?? NoPhotoTakenDateFolderNameDefault;
 		NoAddressFolderName = options.NoAddressFolderName ?? NoAddressFolderNameDefault;
 		NoAddressAndPhotoTakenDateFolderName = options.NoAddressAndPhotoTakenDateFolderName ?? NoAddressAndPhotoTakenDateFolderNameDefault;
@@ -58,7 +60,7 @@ public class ToolOptions
 	public string FolderAppendSeparator { get; set; }
 	public string DayRangeSeparator { get; set; }
 	public string SameNameNumberSeparator { get; set; }
-
+	public string PhotoFormatInvalidFolderName { get; set; }
 	public string NoPhotoTakenDateFolderName { get; set; }
 	public string NoAddressFolderName { get; set; }
 	public string NoAddressAndPhotoTakenDateFolderName { get; set; }

--- a/src/Options/ToolOptionsRaw.cs
+++ b/src/Options/ToolOptionsRaw.cs
@@ -16,6 +16,7 @@ public class ToolOptionsRaw
 	public string? DayRangeSeparator { get; set; }
 	public string? SameNameNumberSeparator { get; set; }
 
+	public string? PhotoFormatInvalidFolderName { get; set; }
 	public string? NoPhotoTakenDateFolderName { get; set; }
 	public string? NoAddressFolderName { get; set; }
 	public string? NoAddressAndPhotoTakenDateFolderName { get; set; }

--- a/src/Options/Validators/ToolOptionsValidator.cs
+++ b/src/Options/Validators/ToolOptionsValidator.cs
@@ -20,6 +20,7 @@ public class ToolOptionsValidator : AbstractValidator<ToolOptions>
 		RuleFor(r => r.FolderAppendSeparator).RequiredString();
 		RuleFor(r => r.DayRangeSeparator).RequiredString();
 		RuleFor(r => r.SameNameNumberSeparator).RequiredString();
+		RuleFor(r => r.PhotoFormatInvalidFolderName).RequiredString();
 		RuleFor(r => r.NoPhotoTakenDateFolderName).RequiredString();
 		RuleFor(r => r.NoAddressFolderName).RequiredString();
 		RuleFor(r => r.NoAddressAndPhotoTakenDateFolderName).RequiredString();

--- a/src/Runners/AddressRunner.cs
+++ b/src/Runners/AddressRunner.cs
@@ -26,7 +26,7 @@ public class AddressRunner : IConsoleRunner
 			return ExitCode.InputFileNotExists;
 
 		var photoExifData = _exifParserService.Parse(_options.InputPath, false, true);
-		if (photoExifData.Coordinate == null)
+		if (photoExifData?.Coordinate == null)
 			return ExitCode.PhotosWithNoCoordinatePreventedProcess;
 
 		switch (_options.AddressListType)

--- a/src/Runners/InfoRunner.cs
+++ b/src/Runners/InfoRunner.cs
@@ -40,11 +40,14 @@ public class InfoRunner : BaseRunner, IConsoleRunner
 		if (!ValidatePhotoPaths(out var exitCodePhotoPaths, photoPaths, sourceFolderPath))
 			return exitCodePhotoPaths;
 
-		var isPreventProcessOptionSelectedNoPhotoTakenDate = _options.NoPhotoTakenDateAction == InfoNoPhotoTakenDateAction.PreventProcess;
-		var isPreventProcessOptionSelectedNoCoordinate = _options.NoCoordinateAction == InfoNoCoordinateAction.PreventProcess;
-		var photoExifDataByPath = _exifDataAppenderService.ExifDataByPath(photoPaths, out var allPhotosHasPhotoTaken, out var allPhotosHasCoordinate);
-		if (!NoExifDataPreventActions(out var exitCodeNoExif, allPhotosHasPhotoTaken, allPhotosHasCoordinate, isPreventProcessOptionSelectedNoPhotoTakenDate,
-			    isPreventProcessOptionSelectedNoCoordinate, photoExifDataByPath))
+		var isNoPhotoTakenDatePreventProcessOptionSelected = _options.NoPhotoTakenDateAction == InfoNoPhotoTakenDateAction.PreventProcess;
+		var isNoCoordinatePreventProcessOptionSelected = _options.NoCoordinateAction == InfoNoCoordinateAction.PreventProcess;
+		var isInvalidFileFormatPreventProcessOptionSelected = _options.InvalidFileFormatAction == InfoInvalidFormatAction.PreventProcess;
+
+		var photoExifDataByPath = _exifDataAppenderService.ExifDataByPath(photoPaths, out var allPhotosAreValid, out var allPhotosHasPhotoTaken, out var allPhotosHasCoordinate);
+		if (!NoExifDataPreventActions(out var exitCodeNoExif, allPhotosAreValid, allPhotosHasPhotoTaken, allPhotosHasCoordinate,
+			    isInvalidFileFormatPreventProcessOptionSelected, isNoPhotoTakenDatePreventProcessOptionSelected, isNoCoordinatePreventProcessOptionSelected,
+			    photoExifDataByPath))
 		{
 			return exitCodeNoExif;
 		}

--- a/src/Runners/SettingsRunner.cs
+++ b/src/Runners/SettingsRunner.cs
@@ -102,7 +102,7 @@ public class SettingsRunner : IConsoleRunner
 
 	private IEnumerable<PropertyInfo> GetProperties()
 	{
-		return typeof(ToolOptions).GetProperties();
+		return typeof(ToolOptions).GetProperties().OrderBy(o => o.Name);
 	}
 
 	private void ConsoleWriteProperty(PropertyInfo property)

--- a/src/Services/Contracts/ICsvService.cs
+++ b/src/Services/Contracts/ICsvService.cs
@@ -3,5 +3,5 @@ namespace PhotoCli.Services.Contracts;
 public interface ICsvService
 {
 	Task Report(IEnumerable<Photo> photos, string outputPath, bool isDryRun = false);
-	Task WriteExifDataToCsvOutput(Dictionary<string, ExifData> photoExifDataByPath, string outputFile);
+	Task WriteExifDataToCsvOutput(Dictionary<string, ExifData?> photoExifDataByPath, string outputFile);
 }

--- a/src/Services/Contracts/IDirectoryGrouperService.cs
+++ b/src/Services/Contracts/IDirectoryGrouperService.cs
@@ -2,6 +2,6 @@ namespace PhotoCli.Services.Contracts;
 
 public interface IDirectoryGrouperService
 {
-	Dictionary<string, List<Photo>> GroupFiles(Dictionary<string, ExifData> photoExifDataByFilePath, string sourceRootPath, FolderProcessType folderProcessType,
-		GroupByFolderType? groupByFolderType, bool noPhotoDateTimeTakenGroupedInSubFolder, bool noReverseGeocodeGroupedInSubFolder);
+	Dictionary<string, List<Photo>> GroupFiles(Dictionary<string, ExifData?> photoExifDataByFilePath, string sourceRootPath, FolderProcessType folderProcessType,
+		GroupByFolderType? groupByFolderType, bool invalidFileFormatGroupedInSubFolder, bool noPhotoDateTimeTakenGroupedInSubFolder, bool noReverseGeocodeGroupedInSubFolder);
 }

--- a/src/Services/Contracts/IExifDataAppenderService.cs
+++ b/src/Services/Contracts/IExifDataAppenderService.cs
@@ -2,5 +2,5 @@ namespace PhotoCli.Services.Contracts;
 
 public interface IExifDataAppenderService
 {
-	Dictionary<string, ExifData> ExifDataByPath(IEnumerable<string> photoPaths, out bool allPhotosHasPhotoTaken, out bool allPhotosHasCoordinate);
+	Dictionary<string, ExifData?> ExifDataByPath(IEnumerable<string> photoPaths, out bool allPhotosAreValid, out bool allPhotosHasPhotoTaken, out bool allPhotosHasCoordinate);
 }

--- a/src/Services/Contracts/IExifOrganizerService.cs
+++ b/src/Services/Contracts/IExifOrganizerService.cs
@@ -2,6 +2,6 @@ namespace PhotoCli.Services.Contracts;
 
 public interface IExifOrganizerService
 {
-	(IReadOnlyCollection<Photo>, IReadOnlyCollection<Photo>) FilterAndSortByNoActionTypes(IReadOnlyCollection<Photo> photoInfos, CopyNoPhotoTakenDateAction noPhotoDateTimeTakenAction,
-		CopyNoCoordinateAction noCoordinateAction);
+	(IReadOnlyCollection<Photo>, IReadOnlyCollection<Photo>) FilterAndSortByNoActionTypes(IReadOnlyCollection<Photo> photoInfos, CopyInvalidFormatAction invalidFormatAction,
+		CopyNoPhotoTakenDateAction noPhotoDateTimeTakenAction, CopyNoCoordinateAction noCoordinateAction, string targetRelativeDirectoryPath);
 }

--- a/src/Services/Contracts/IExifParserService.cs
+++ b/src/Services/Contracts/IExifParserService.cs
@@ -2,5 +2,5 @@ namespace PhotoCli.Services.Contracts;
 
 public interface IExifParserService
 {
-	ExifData Parse(string filePath, bool parseDateTime, bool parseCoordinate);
+	ExifData? Parse(string filePath, bool parseDateTime, bool parseCoordinate);
 }

--- a/src/Services/Contracts/IReverseGeocodeFetcherService.cs
+++ b/src/Services/Contracts/IReverseGeocodeFetcherService.cs
@@ -2,6 +2,6 @@
 
 public interface IReverseGeocodeFetcherService
 {
-	Task<Dictionary<string, ExifData>> Fetch(Dictionary<string, ExifData> exifDataByFilePath);
+	Task<Dictionary<string, ExifData?>> Fetch(Dictionary<string, ExifData?> exifDataByFilePath);
 	void RateLimitWarning();
 }

--- a/src/Services/Implementations/CsvService.cs
+++ b/src/Services/Implementations/CsvService.cs
@@ -39,7 +39,7 @@ public class CsvService : ICsvService
 		_consoleWriter.ProgressFinish(ProgressName);
 	}
 
-	public async Task WriteExifDataToCsvOutput(Dictionary<string, ExifData> photoExifDataByPath, string outputFile)
+	public async Task WriteExifDataToCsvOutput(Dictionary<string, ExifData?> photoExifDataByPath, string outputFile)
 	{
 		_consoleWriter.ProgressStart(ProgressName);
 		var photoCsvModels = new List<PhotoCsv>();
@@ -63,12 +63,12 @@ public class CsvService : ICsvService
 		await csv.WriteRecordsAsync(photoCsvModels);
 	}
 
-	private PhotoCsv ExifDataToPhotoCsv(ExifData exifData, string photoPath, string? photoNewPath = null, string? sha1Hash = null)
+	private PhotoCsv ExifDataToPhotoCsv(ExifData? exifData, string photoPath, string? photoNewPath = null, string? sha1Hash = null)
 	{
-		var takenDate = exifData.TakenDate;
-		var coordinate = exifData.Coordinate;
-		var reverseGeocodes = exifData.ReverseGeocodes?.ToList();
-		var photoCsv = new PhotoCsv(photoPath, photoNewPath, takenDate, exifData.ReverseGeocodeFormatted, coordinate?.Latitude, coordinate?.Longitude, takenDate?.Year,
+		var takenDate = exifData?.TakenDate;
+		var coordinate = exifData?.Coordinate;
+		var reverseGeocodes = exifData?.ReverseGeocodes?.ToList();
+		var photoCsv = new PhotoCsv(photoPath, photoNewPath, takenDate, exifData?.ReverseGeocodeFormatted, coordinate?.Latitude, coordinate?.Longitude, takenDate?.Year,
 			takenDate?.Month, takenDate?.Day,
 			takenDate?.Hour, takenDate?.Minute, takenDate?.Second, reverseGeocodes?.ElementAtOrDefault(0), reverseGeocodes?.ElementAtOrDefault(1), reverseGeocodes?.ElementAtOrDefault(2),
 			reverseGeocodes?.ElementAtOrDefault(3), reverseGeocodes?.ElementAtOrDefault(4), reverseGeocodes?.ElementAtOrDefault(5), reverseGeocodes?.ElementAtOrDefault(6),

--- a/src/Services/Implementations/PhotoCollectorService.cs
+++ b/src/Services/Implementations/PhotoCollectorService.cs
@@ -39,7 +39,7 @@ public class PhotoCollectorService : IPhotoCollectorService
 			_logger.LogCritical(unauthorizedAccessException, message);
 			throw new PhotoCliException($"{message} -> {unauthorizedAccessException.Message}");
 		}
-		_consoleWriter.ProgressFinish(ProgressName, $"{filePaths.Length} photos found.");
+		_consoleWriter.ProgressFinish(ProgressName, $"{filePaths.Length} photo(s) found.");
 		_statistics.PhotosFound = filePaths.Length;
 		return filePaths;
 	}

--- a/src/Services/Implementations/ReverseGeocodeFetcherService.cs
+++ b/src/Services/Implementations/ReverseGeocodeFetcherService.cs
@@ -32,7 +32,7 @@ public class ReverseGeocodeFetcherService : IReverseGeocodeFetcherService
 		_logger = logger;
 	}
 
-	public async Task<Dictionary<string, ExifData>> Fetch(Dictionary<string, ExifData> exifDataByFilePath)
+	public async Task<Dictionary<string, ExifData?>> Fetch(Dictionary<string, ExifData?> exifDataByFilePath)
 	{
 		_consoleWriter.ProgressStart(ProgressName, _statistics.HasCoordinateCount);
 
@@ -43,7 +43,7 @@ public class ReverseGeocodeFetcherService : IReverseGeocodeFetcherService
 
 		foreach (var (filePath, exifData) in exifDataByFilePath)
 		{
-			if (exifData.Coordinate == null)
+			if (exifData?.Coordinate == null)
 			{
 				_logger.LogTrace("No coordinate found, skipping {FilePath}", filePath);
 				continue;
@@ -75,7 +75,11 @@ public class ReverseGeocodeFetcherService : IReverseGeocodeFetcherService
 		_logger.LogDebug("All queued reverse geocode requests have been finished");
 
 		foreach (var (photoPath, reverseGeocodeRequest) in fileBasedReverseGeocodeRequests)
-			exifDataByFilePath[photoPath].ReverseGeocodes = reverseGeocodeRequest.Result;
+		{
+			var exifData = exifDataByFilePath[photoPath];
+			if(exifData != null)
+				exifData.ReverseGeocodes = reverseGeocodeRequest.Result;
+		}
 
 		_consoleWriter.ProgressFinish(ProgressName);
 		return exifDataByFilePath;

--- a/src/Utils/HelpTextBuilder.cs
+++ b/src/Utils/HelpTextBuilder.cs
@@ -30,34 +30,33 @@ public static class HelpTextBuilder
 				break;
 			case OptionNames.InfoVerb:
 				WriteOptionArgumentsToConsole(
-					new InfoOptions("[output-file].csv", "[input-folder]", true, InfoNoPhotoTakenDateAction.Continue, InfoNoCoordinateAction.Continue, ReverseGeocodeProvider.OpenStreetMapFoundation,
+					new InfoOptions("[output-file].csv", "[input-folder]", true, InfoInvalidFormatAction.Continue, InfoNoPhotoTakenDateAction.Continue, InfoNoCoordinateAction.Continue, ReverseGeocodeProvider.OpenStreetMapFoundation,
 						openStreetMapProperties: new[] { "country", "city", "town", "suburb" }),
 					"Photos located on all subfolders will be processed and their photograph's taken date and address information will be saved on CSV file using BigDataCloud reverse geocode provider.",
 					textWriter);
 
 				WriteOptionArgumentsToConsole(
-					new InfoOptions("[output-file].csv", "[input-folder]", false, InfoNoPhotoTakenDateAction.PreventProcess, InfoNoCoordinateAction.PreventProcess,
-						ReverseGeocodeProvider.GoogleMaps, googleMapsAddressTypes: new[] { "administrative_area_level_1", "administrative_area_level_2" }, googleMapsApiKey: "google-api-key"),
+					new InfoOptions("[output-file].csv", "[input-folder]", false, InfoInvalidFormatAction.Continue, InfoNoPhotoTakenDateAction.PreventProcess, InfoNoCoordinateAction.PreventProcess, ReverseGeocodeProvider.GoogleMaps, googleMapsAddressTypes: new[] { "administrative_area_level_1", "administrative_area_level_2" }, googleMapsApiKey: "google-api-key"),
 					"Using Google Maps reverse geocode provider (need api key) with an option to prevent processing if there is no coordinate or no photo taken date found on any photo.", textWriter);
 				break;
 			case OptionNames.CopyVerb:
 
 				WriteOptionArgumentsToConsole(
 					new CopyOptions("[output-folder]", NamingStyle.Numeric, FolderProcessType.SubFoldersPreserveFolderHierarchy, NumberNamingTextStyle.PaddingZeroCharacter,
-						CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.Continue, "[input-folder]"),
+						CopyInvalidFormatAction.Continue, CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.Continue, "[input-folder]"),
 					"Preserve same folder hierarchy, copy photos with sequential number ordering by photo taken date.",
 					textWriter);
 
 				WriteOptionArgumentsToConsole(
 					new CopyOptions("[output-folder]", NamingStyle.DateTimeWithSeconds, FolderProcessType.FlattenAllSubFolders, NumberNamingTextStyle.OnlySequentialNumbers,
-						CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.Continue, "[input-folder]",
+						CopyInvalidFormatAction.Continue, CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.Continue, "[input-folder]",
 						groupByFolderType: GroupByFolderType.YearMonthDay),
 					"Groups photos by photo taken year, month, day than copy on [year]/[month]/[day] directory with a file name as photo taken date.",
 					textWriter);
 
 				WriteOptionArgumentsToConsole(
 					new CopyOptions("[output-folder]", NamingStyle.AddressDay, FolderProcessType.SubFoldersPreserveFolderHierarchy, NumberNamingTextStyle.AllNamesAreSameLength,
-						CopyNoPhotoTakenDateAction.InSubFolder, CopyNoCoordinateAction.InSubFolder, "[input-folder]", folderAppendType: FolderAppendType.DayRange,
+						CopyInvalidFormatAction.PreventProcess, CopyNoPhotoTakenDateAction.InSubFolder, CopyNoCoordinateAction.InSubFolder, "[input-folder]", folderAppendType: FolderAppendType.DayRange,
 						folderAppendLocationType: FolderAppendLocationType.Prefix, reverseGeoCodeProvider: ReverseGeocodeProvider.GoogleMaps,
 						googleMapsAddressTypes: new[] { "administrative_area_level_1", "administrative_area_level_2", "administrative_area_level_3" }, googleMapsApiKey: "google-api-key"),
 					"Adding day range as a prefix to existing folder names and photos copied with a file name as address and day.",
@@ -65,14 +64,14 @@ public static class HelpTextBuilder
 
 				WriteOptionArgumentsToConsole(
 					new CopyOptions("[output-folder]", NamingStyle.AddressDateTimeWithSeconds, FolderProcessType.SubFoldersPreserveFolderHierarchy, NumberNamingTextStyle.AllNamesAreSameLength,
-						CopyNoPhotoTakenDateAction.InSubFolder, CopyNoCoordinateAction.InSubFolder, "[input-folder]", reverseGeoCodeProvider: ReverseGeocodeProvider.OpenStreetMapFoundation,
+						CopyInvalidFormatAction.PreventProcess, CopyNoPhotoTakenDateAction.InSubFolder, CopyNoCoordinateAction.InSubFolder, "[input-folder]", reverseGeoCodeProvider: ReverseGeocodeProvider.OpenStreetMapFoundation,
 						openStreetMapProperties: new[] { "country", "city", "town", "suburb" }),
 					"Preserve same folder hierarchy, copy photos with a file name as photo taken date, time and address. Possible file name will have number suffix. Photos that don't have any coordinate or photo taken date will be copied in a relative subfolder.",
 					textWriter);
 
 				WriteOptionArgumentsToConsole(
 					new CopyOptions("[output-folder]", NamingStyle.DayAddress, FolderProcessType.FlattenAllSubFolders, NumberNamingTextStyle.OnlySequentialNumbers,
-						CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.InSubFolder, "[input-folder]", groupByFolderType: GroupByFolderType.AddressHierarchy,
+						CopyInvalidFormatAction.PreventProcess, CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.InSubFolder, "[input-folder]", groupByFolderType: GroupByFolderType.AddressHierarchy,
 						reverseGeoCodeProvider: ReverseGeocodeProvider.BigDataCloud, bigDataCloudAdminLevels: new[] { 2, 4, 6, 8 }),
 					"Groups photos by photo taken year, month, day than copy on [year]/[month]/[day] directory with a file name as photo taken date. Photos that don't have any coordinate will be copied in a relative subfolder.",
 					textWriter);

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -9,6 +9,7 @@
   "DateFormatWithDay": "yyyy.MM.dd",
   "DateTimeFormatWithMinutes": "yyyy.MM.dd_HH.mm",
   "DateTimeFormatWithSeconds": "yyyy.MM.dd_HH.mm.ss",
+  "PhotoFormatInvalidFolderName": "invalid-photo-format",
   "NoPhotoTakenDateFolderName": "no-photo-taken-date",
   "NoAddressFolderName": "no-address",
   "NoAddressAndPhotoTakenDateFolderName": "no-address-and-no-photo-taken-date",

--- a/tests/EndToEndTests/BaseEndToEndTests.cs
+++ b/tests/EndToEndTests/BaseEndToEndTests.cs
@@ -264,12 +264,12 @@ public abstract class BaseEndToEndTests : IClassFixture<SetEnvironmentVariablesF
 
 	protected ConsoleOutputValues ParseConsoleOutput(string actualOutput)
 	{
-		var photosFound = GetRegexValue(@"(.\d+) photos found.", actualOutput);
-		var photosCopied = GetRegexValue(@"(.\d+) photos copied.", actualOutput);
-		var hasTakenDateAndCoordinate = GetRegexValue(@"(.\d+) photos has taken date and coordinate.", actualOutput);
-		var hasTakenDateButNoCoordinate = GetRegexValue(@"(.\d+) photos has taken date but no coordinate.", actualOutput);
-		var hasNoTakenDateAndCoordinate = GetRegexValue(@"(.\d+) photos has no taken date and coordinate.", actualOutput);
-		var directoriesCreated = GetRegexValue(@"(.\d+) directories created.", actualOutput);
+		var photosFound = GetRegexValue(@"(.\d+) photo\(s\) found.", actualOutput);
+		var photosCopied = GetRegexValue(@"(.\d+) photo\(s\) copied.", actualOutput);
+		var hasTakenDateAndCoordinate = GetRegexValue(@"(.\d+) photo\(s\) has taken date and coordinate.", actualOutput);
+		var hasTakenDateButNoCoordinate = GetRegexValue(@"(.\d+) photo\(s\) has taken date but no coordinate.", actualOutput);
+		var hasNoTakenDateAndCoordinate = GetRegexValue(@"(.\d+) photo\(s\) has no taken date and coordinate.", actualOutput);
+		var directoriesCreated = GetRegexValue(@"(.\d+) directory/directories created.", actualOutput);
 		return new ConsoleOutputValues(photosFound, photosCopied, hasTakenDateAndCoordinate, hasTakenDateButNoCoordinate, hasNoTakenDateAndCoordinate, directoriesCreated);
 	}
 

--- a/tests/EndToEndTests/CopyVerbEndToEndTests.cs
+++ b/tests/EndToEndTests/CopyVerbEndToEndTests.cs
@@ -266,7 +266,7 @@ public class CopyVerbEndToEndTests : BaseEndToEndTests
 	{
 		{
 			CommandLineArgumentsFakes.CopyBuildCommandLineOptions(OutputPath, TestImagesPathHelper.SingleFolder(), NamingStyle.Address, FolderProcessType.Single,
-				NumberNamingTextStyle.OnlySequentialNumbers, CopyNoPhotoTakenDateAction.DontCopyToOutput, CopyNoCoordinateAction.DontCopyToOutput, false,
+				NumberNamingTextStyle.OnlySequentialNumbers, CopyNoPhotoTakenDateAction.DontCopyToOutput, CopyNoCoordinateAction.DontCopyToOutput,
 				reverseGeocodeProvider: ReverseGeocodeProvider.BigDataCloud, bigDataCloudAdminLevels: new List<string> { "3", "4", "5", "6", "7" }),
 			new List<PhotoCsv>
 			{
@@ -852,7 +852,7 @@ public class CopyVerbEndToEndTests : BaseEndToEndTests
 	{
 		{
 			CommandLineArgumentsFakes.CopyBuildCommandLineOptions(OutputPath, TestImagesPathHelper.SubFolders(), NamingStyle.Day, FolderProcessType.FlattenAllSubFolders,
-				NumberNamingTextStyle.AllNamesAreSameLength, CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.Continue, false, GroupByFolderType.AddressHierarchy,
+				NumberNamingTextStyle.AllNamesAreSameLength, CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction.Continue, groupByFolderType: GroupByFolderType.AddressHierarchy,
 				reverseGeocodeProvider: ReverseGeocodeProvider.BigDataCloud, bigDataCloudAdminLevels: new List<string> { "3", "4", "5", "6", "7" }),
 			new List<PhotoCsv>
 			{
@@ -1104,7 +1104,7 @@ public class CopyVerbEndToEndTests : BaseEndToEndTests
 	{
 		{
 			CommandLineArgumentsFakes.CopyBuildCommandLineOptions(OutputPath, TestImagesPathHelper.SubFolders(), NamingStyle.Address, FolderProcessType.SubFoldersPreserveFolderHierarchy,
-				NumberNamingTextStyle.PaddingZeroCharacter, CopyNoPhotoTakenDateAction.DontCopyToOutput, CopyNoCoordinateAction.DontCopyToOutput, false,
+				NumberNamingTextStyle.PaddingZeroCharacter, CopyNoPhotoTakenDateAction.DontCopyToOutput, CopyNoCoordinateAction.DontCopyToOutput,
 				reverseGeocodeProvider: ReverseGeocodeProvider.BigDataCloud,
 				bigDataCloudAdminLevels: new List<string> { "3", "4", "5", "6", "7" }),
 			new List<PhotoCsv>
@@ -1166,7 +1166,7 @@ public class CopyVerbEndToEndTests : BaseEndToEndTests
 	{
 		{
 			CommandLineArgumentsFakes.CopyBuildCommandLineOptions(OutputPath, TestImagesPathHelper.SubFolders(), NamingStyle.DayAddress, FolderProcessType.SubFoldersPreserveFolderHierarchy,
-				NumberNamingTextStyle.OnlySequentialNumbers, CopyNoPhotoTakenDateAction.DontCopyToOutput, CopyNoCoordinateAction.DontCopyToOutput, false,
+				NumberNamingTextStyle.OnlySequentialNumbers, CopyNoPhotoTakenDateAction.DontCopyToOutput, CopyNoCoordinateAction.DontCopyToOutput,
 				reverseGeocodeProvider: ReverseGeocodeProvider.BigDataCloud, bigDataCloudAdminLevels: new List<string> { "3", "4", "5", "6", "7" }),
 			new List<PhotoCsv>
 			{

--- a/tests/EndToEndTests/HelpVerbEndToEndTests.cs
+++ b/tests/EndToEndTests/HelpVerbEndToEndTests.cs
@@ -50,26 +50,26 @@ photo-cli copy -f FlattenAllSubFolders -g YearMonthDay -i [input-folder] -n Only
 - Adding day range as a prefix to existing folder names and photos copied with a file name as address and day.
 
 Example with long argument names;
-photo-cli copy --folder-append DayRange --no-coordinate InSubFolder --reverse-geocode GoogleMaps --process-type SubFoldersPreserveFolderHierarchy --input [input-folder] --googlemaps-key google-api-key --googlemaps-types administrative_area_level_1 administrative_area_level_2 administrative_area_level_3 --number-style AllNamesAreSameLength --output [output-folder] --folder-append-location Prefix --naming-style AddressDay --no-taken-date InSubFolder
+photo-cli copy --folder-append DayRange --no-coordinate InSubFolder --reverse-geocode GoogleMaps --process-type SubFoldersPreserveFolderHierarchy --input [input-folder] --googlemaps-key google-api-key --googlemaps-types administrative_area_level_1 administrative_area_level_2 administrative_area_level_3 --number-style AllNamesAreSameLength --output [output-folder] --folder-append-location Prefix --naming-style AddressDay --no-taken-date InSubFolder --invalid-format PreventProcess
 
 Example with short argument names;
-photo-cli copy -a DayRange -c InSubFolder -e GoogleMaps -f SubFoldersPreserveFolderHierarchy -i [input-folder] -k google-api-key -m administrative_area_level_1 administrative_area_level_2 administrative_area_level_3 -n AllNamesAreSameLength -o [output-folder] -p Prefix -s AddressDay -t InSubFolder
+photo-cli copy -a DayRange -c InSubFolder -e GoogleMaps -f SubFoldersPreserveFolderHierarchy -i [input-folder] -k google-api-key -m administrative_area_level_1 administrative_area_level_2 administrative_area_level_3 -n AllNamesAreSameLength -o [output-folder] -p Prefix -s AddressDay -t InSubFolder -x PreventProcess
 
 - Preserve same folder hierarchy, copy photos with a file name as photo taken date, time and address. Possible file name will have number suffix. Photos that don't have any coordinate or photo taken date will be copied in a relative subfolder.
 
 Example with long argument names;
-photo-cli copy --no-coordinate InSubFolder --reverse-geocode OpenStreetMapFoundation --process-type SubFoldersPreserveFolderHierarchy --input [input-folder] --number-style AllNamesAreSameLength --output [output-folder] --openstreetmap-properties country city town suburb --naming-style AddressDateTimeWithSeconds --no-taken-date InSubFolder
+photo-cli copy --no-coordinate InSubFolder --reverse-geocode OpenStreetMapFoundation --process-type SubFoldersPreserveFolderHierarchy --input [input-folder] --number-style AllNamesAreSameLength --output [output-folder] --openstreetmap-properties country city town suburb --naming-style AddressDateTimeWithSeconds --no-taken-date InSubFolder --invalid-format PreventProcess
 
 Example with short argument names;
-photo-cli copy -c InSubFolder -e OpenStreetMapFoundation -f SubFoldersPreserveFolderHierarchy -i [input-folder] -n AllNamesAreSameLength -o [output-folder] -r country city town suburb -s AddressDateTimeWithSeconds -t InSubFolder
+photo-cli copy -c InSubFolder -e OpenStreetMapFoundation -f SubFoldersPreserveFolderHierarchy -i [input-folder] -n AllNamesAreSameLength -o [output-folder] -r country city town suburb -s AddressDateTimeWithSeconds -t InSubFolder -x PreventProcess
 
 - Groups photos by photo taken year, month, day than copy on [year]/[month]/[day] directory with a file name as photo taken date. Photos that don't have any coordinate will be copied in a relative subfolder.
 
 Example with long argument names;
-photo-cli copy --no-coordinate InSubFolder --reverse-geocode BigDataCloud --process-type FlattenAllSubFolders --group-by AddressHierarchy --input [input-folder] --number-style OnlySequentialNumbers --output [output-folder] --naming-style DayAddress --bigdatacloud-levels 2 4 6 8
+photo-cli copy --no-coordinate InSubFolder --reverse-geocode BigDataCloud --process-type FlattenAllSubFolders --group-by AddressHierarchy --input [input-folder] --number-style OnlySequentialNumbers --output [output-folder] --naming-style DayAddress --bigdatacloud-levels 2 4 6 8 --invalid-format PreventProcess
 
 Example with short argument names;
-photo-cli copy -c InSubFolder -e BigDataCloud -f FlattenAllSubFolders -g AddressHierarchy -i [input-folder] -n OnlySequentialNumbers -o [output-folder] -s DayAddress -u 2 4 6 8
+photo-cli copy -c InSubFolder -e BigDataCloud -f FlattenAllSubFolders -g AddressHierarchy -i [input-folder] -n OnlySequentialNumbers -o [output-folder] -s DayAddress -u 2 4 6 8 -x PreventProcess
 ";
 
 		await RunHelpAndVerifyOutput("copy", copyExampleUsages);

--- a/tests/EndToEndTests/SettingsVerbEndToEndTests.cs
+++ b/tests/EndToEndTests/SettingsVerbEndToEndTests.cs
@@ -23,7 +23,8 @@ public class SettingsVerbEndToEndTests : BaseEndToEndTests
     ""AddressSeparator"": ""-"",
     ""FolderAppendSeparator"": ""-"",
     ""DayRangeSeparator"": ""-"",
-	""SameNameNumberSeparator"": ""-"",
+    ""SameNameNumberSeparator"": ""-"",
+    ""PhotoFormatInvalidFolderName"": ""invalid-photo-format"",
     ""NoPhotoTakenDateFolderName"": ""no-photo-taken-date"",
     ""NoAddressFolderName"": ""no-address"",
     ""NoAddressAndPhotoTakenDateFolderName"": ""no-address-and-no-photo-taken-date"",
@@ -51,6 +52,7 @@ AddressSeparator=-
 FolderAppendSeparator=-
 DayRangeSeparator=-
 SameNameNumberSeparator=-
+PhotoFormatInvalidFolderName=invalid-photo-format
 NoPhotoTakenDateFolderName=no-photo-taken-date
 NoAddressFolderName=no-address
 NoAddressAndPhotoTakenDateFolderName=no-address-and-no-photo-taken-date

--- a/tests/EndToEndTests/SettingsVerbEndToEndTests.cs
+++ b/tests/EndToEndTests/SettingsVerbEndToEndTests.cs
@@ -40,28 +40,28 @@ public class SettingsVerbEndToEndTests : BaseEndToEndTests
 	{
 		{
 			CommandLineArgumentsFakes.SettingsBuildCommandLineOptions(),
-			@"LogLevel=Error
-YearFormat=yyyy
-MonthFormat=MM
-DayFormat=dd
-DateFormatWithMonth=yyyy.MM
+			@"AddressSeparator=-
+BigDataCloudApiKey=
+ConnectionLimit=4
+CsvReportFileName=photo-cli-report.csv
 DateFormatWithDay=yyyy.MM.dd
+DateFormatWithMonth=yyyy.MM
 DateTimeFormatWithMinutes=yyyy.MM.dd_HH.mm
 DateTimeFormatWithSeconds=yyyy.MM.dd_HH.mm.ss
-AddressSeparator=-
-FolderAppendSeparator=-
+DayFormat=dd
 DayRangeSeparator=-
-SameNameNumberSeparator=-
-PhotoFormatInvalidFolderName=invalid-photo-format
-NoPhotoTakenDateFolderName=no-photo-taken-date
-NoAddressFolderName=no-address
-NoAddressAndPhotoTakenDateFolderName=no-address-and-no-photo-taken-date
-CsvReportFileName=photo-cli-report.csv
 DryRunCsvReportFileName=photo-cli-dry-run.csv
-ConnectionLimit=4
-BigDataCloudApiKey=
+FolderAppendSeparator=-
 GoogleMapsApiKey=
-LocationIqApiKey="
+LocationIqApiKey=
+LogLevel=Error
+MonthFormat=MM
+NoAddressAndPhotoTakenDateFolderName=no-address-and-no-photo-taken-date
+NoAddressFolderName=no-address
+NoPhotoTakenDateFolderName=no-photo-taken-date
+PhotoFormatInvalidFolderName=invalid-photo-format
+SameNameNumberSeparator=-
+YearFormat=yyyy"
 		}
 	};
 

--- a/tests/Fakes/CommandLineArgumentsFakes.cs
+++ b/tests/Fakes/CommandLineArgumentsFakes.cs
@@ -11,9 +11,9 @@ public static class CommandLineArgumentsFakes
 
 
 	public static string[] CopyBuildCommandLineOptions(string outputPath, string sourcePhotoPath, NamingStyle namingStyle, FolderProcessType folderProcessType,
-		NumberNamingTextStyle numberNamingTextStyle, CopyNoPhotoTakenDateAction noPhotoTakenDateAction, CopyNoCoordinateAction noCoordinateAction, bool isDryRun = false,
-		GroupByFolderType? groupByFolderType = null, FolderAppendType? folderAppendType = null, FolderAppendLocationType? folderAppendLocationType = null,
-		ReverseGeocodeProvider? reverseGeocodeProvider = null, List<string>? bigDataCloudAdminLevels = null)
+		NumberNamingTextStyle numberNamingTextStyle, CopyNoPhotoTakenDateAction noPhotoTakenDateAction, CopyNoCoordinateAction noCoordinateAction,
+		bool isDryRun = false, GroupByFolderType? groupByFolderType = null, FolderAppendType? folderAppendType = null, FolderAppendLocationType? folderAppendLocationType = null,
+		ReverseGeocodeProvider? reverseGeocodeProvider = null, List<string>? bigDataCloudAdminLevels = null, CopyInvalidFormatAction invalidFormatAction = CopyInvalidFormatAction.PreventProcess)
 	{
 		var args = new List<string> { "copy" };
 
@@ -24,8 +24,9 @@ public static class CommandLineArgumentsFakes
 		AddArgumentWithParameter('i', sourcePhotoPath, args);
 		AddArgumentWithParameter('t', noPhotoTakenDateAction.ToString(), args);
 		AddArgumentWithParameter('c', noCoordinateAction.ToString(), args);
+		AddArgumentWithParameter('x', invalidFormatAction.ToString(), args);
 
-		if (isDryRun)
+		if(isDryRun)
 			AddArgumentWithoutParameter('d', args);
 
 		if (reverseGeocodeProvider != null)

--- a/tests/Fakes/CopyInvalidFormatActionFakes.cs
+++ b/tests/Fakes/CopyInvalidFormatActionFakes.cs
@@ -1,0 +1,9 @@
+namespace PhotoCli.Tests.Fakes;
+
+public static class CopyInvalidFormatActionFakes
+{
+	public static CopyInvalidFormatAction Valid()
+	{
+		return CopyInvalidFormatAction.PreventProcess;
+	}
+}

--- a/tests/Fakes/DateTimeFakes.cs
+++ b/tests/Fakes/DateTimeFakes.cs
@@ -80,6 +80,11 @@ public static class DateTimeFakes
 		return new DateTime(YearDefault, MonthDefault, DayDefault, HourDefault, MinuteDefault, second);
 	}
 
+	public static DateTime Valid()
+	{
+		return DateTime.MinValue;
+	}
+
 	public static string FormatSecond(int second)
 	{
 		var dateTime = WithSecond(second);

--- a/tests/Fakes/ExifDataFakes.cs
+++ b/tests/Fakes/ExifDataFakes.cs
@@ -6,6 +6,11 @@ public static class ExifDataFakes
 	private const int MonthDefault = 1;
 	private const int DayDefault = 1;
 
+	public static ExifData Valid()
+	{
+		return WithDay(1);
+	}
+
 	public static ExifData WithDay(int day)
 	{
 		return Create(new DateTime(YearDefault, MonthDefault, day));
@@ -26,6 +31,11 @@ public static class ExifDataFakes
 		return Create(new DateTime(year, MonthDefault, DayDefault));
 	}
 
+	public static ExifData WithYearAndReverseGeocode(int year)
+	{
+		return Create(new DateTime(year, MonthDefault, DayDefault), reverseGeocodes: ReverseGeocodeFakes.Valid());
+	}
+
 	public static ExifData WithDayAndReverseGeocodeSampleId(int day, int sampleId)
 	{
 		return Create(new DateTime(YearDefault, MonthDefault, day), reverseGeocodes: ReverseGeocodeFakes.Sample(sampleId));
@@ -38,27 +48,27 @@ public static class ExifDataFakes
 
 	public static ExifData WithNoPhotoTakenDate()
 	{
-		return Create();
+		return new ExifData(null, CoordinateFakes.Valid(), ToolOptionFakes.AddressSeparator) { ReverseGeocodes = ReverseGeocodeFakes.Valid()};
 	}
 
 	public static ExifData WithNoCoordinate()
 	{
-		return Create();
-	}
-
-	public static ExifData NoData()
-	{
-		return Create();
+		return new ExifData(DateTimeFakes.Valid(), null, ToolOptionFakes.AddressSeparator);
 	}
 
 	public static ExifData WithNoReverseGeocode()
 	{
-		return Create();
+		return new ExifData(DateTimeFakes.Valid(), null, ToolOptionFakes.AddressSeparator);
 	}
 
 	public static ExifData WithNoReverseGeocodeAndNoTakenDate()
 	{
-		return Create();
+		return new ExifData(null, null, ToolOptionFakes.AddressSeparator);;
+	}
+
+	public static ExifData? WithInvalidFileFormat()
+	{
+		return null;
 	}
 
 	public static ExifData WithCoordinate(Coordinate coordinate)

--- a/tests/Fakes/Options/CopyOptionsFakes.cs
+++ b/tests/Fakes/Options/CopyOptionsFakes.cs
@@ -9,9 +9,12 @@ public static class CopyOptionsFakes
 		return Create(outputFolderPath, sourcePhotosFolderPathOptional: sourceFolderPath);
 	}
 
-	public static CopyOptions WithNoExifDataAction(string sourceFolderPath, CopyNoPhotoTakenDateAction noPhotoTakenDateAction, CopyNoCoordinateAction noCoordinateAction)
+	public static CopyOptions WithPreventAction(string sourceFolderPath, CopyInvalidFormatAction invalidFormatAction,
+		CopyNoPhotoTakenDateAction noPhotoTakenDateAction, CopyNoCoordinateAction noCoordinateAction)
 	{
-		return Create(sourcePhotosFolderPathOptional: sourceFolderPath, noPhotoTakenDateActionOptional: noPhotoTakenDateAction,
+		return Create(sourcePhotosFolderPathOptional: sourceFolderPath,
+			invalidFormatActionOptional: invalidFormatAction,
+			noPhotoTakenDateActionOptional: noPhotoTakenDateAction,
 			noCoordinateActionOptional: noCoordinateAction);
 	}
 
@@ -71,31 +74,29 @@ public static class CopyOptionsFakes
 
 	public static CopyOptions Create(
 		// required
-		string? outputPath = ValidOutputPath, NamingStyle? namingStyleRequired = null, FolderProcessType? folderProcessTypeRequired = null,
-		NumberNamingTextStyle? numberNamingTextStyleRequired = null, CopyNoPhotoTakenDateAction? noPhotoTakenDateActionOptional = null, CopyNoCoordinateAction? noCoordinateActionOptional = null,
+		string? outputPath = ValidOutputPath, NamingStyle? namingStyleRequired = null, FolderProcessType? folderProcessTypeRequired = null, NumberNamingTextStyle? numberNamingTextStyleRequired = null,
 		// optional
+		CopyInvalidFormatAction? invalidFormatActionOptional = null , CopyNoPhotoTakenDateAction? noPhotoTakenDateActionOptional = null, CopyNoCoordinateAction? noCoordinateActionOptional = null,
 		string? sourcePhotosFolderPathOptional = null, bool isDryRunOptional = false, GroupByFolderType? groupByFolderTypeOptional = null,
 		FolderAppendType? folderAppendTypeOptional = null, FolderAppendLocationType? folderAppendLocationTypeOptional = null, bool verify = false,
 		// shared ReverseGeocode
 		ReverseGeocodeProvider reverseGeoCodeProviderOptional = ReverseGeocodeProvider.Disabled,
-		IEnumerable<int>? bigDataCloudAdminLevelsOptional = null)
+		IEnumerable<int>? bigDataCloudAdminLevelsOptional = null, bool? hasPaidLicenseOptional = false)
 	{
 		return new CopyOptions(outputPath!, namingStyleRequired ?? NamingStyleFakes.Valid(),
 			folderProcessTypeRequired ?? FolderProcessTypeFakes.Valid(), numberNamingTextStyleRequired ?? NumberNamingTextStyleFakes.Valid(),
-			noPhotoTakenDateActionOptional ?? CopyNoPhotoTakenDateActionFakes.Valid(), noCoordinateActionOptional ?? CopyNoCoordinateActionFakes.Valid(), sourcePhotosFolderPathOptional,
-			isDryRunOptional, groupByFolderTypeOptional, folderAppendTypeOptional, folderAppendLocationTypeOptional, verify, reverseGeoCodeProviderOptional,
-			bigDataCloudAdminLevels: bigDataCloudAdminLevelsOptional);
+			invalidFormatActionOptional ?? CopyInvalidFormatActionFakes.Valid() , noPhotoTakenDateActionOptional ?? CopyNoPhotoTakenDateActionFakes.Valid(), noCoordinateActionOptional ?? CopyNoCoordinateActionFakes.Valid(),
+			sourcePhotosFolderPathOptional, isDryRunOptional, groupByFolderTypeOptional, folderAppendTypeOptional, folderAppendLocationTypeOptional, verify, reverseGeoCodeProviderOptional,
+			bigDataCloudAdminLevels: bigDataCloudAdminLevelsOptional, hasPaidLicense: hasPaidLicenseOptional);
 	}
 
 	public static CopyOptions ValidReverseGeocodeService(ReverseGeocodeProvider reverseGeocodeProvider = ReverseGeocodeProvider.BigDataCloud)
 	{
-		return new CopyOptions(ValidOutputPath, NamingStyleFakes.Valid(), FolderProcessTypeFakes.Valid(), NumberNamingTextStyleFakes.Valid(), CopyNoPhotoTakenDateActionFakes.Valid(),
-			CopyNoCoordinateActionFakes.Valid(), reverseGeoCodeProvider: reverseGeocodeProvider);
+		return Create(reverseGeoCodeProviderOptional: reverseGeocodeProvider);
 	}
 
 	public static CopyOptions ValidReverseGeocodeServiceWithLicense(bool hasPaidLicense, ReverseGeocodeProvider reverseGeocodeProvider = ReverseGeocodeProvider.BigDataCloud)
 	{
-		return new CopyOptions(ValidOutputPath, NamingStyleFakes.Valid(), FolderProcessTypeFakes.Valid(), NumberNamingTextStyleFakes.Valid(), CopyNoPhotoTakenDateActionFakes.Valid(),
-			CopyNoCoordinateActionFakes.Valid(), reverseGeoCodeProvider: reverseGeocodeProvider, hasPaidLicense: hasPaidLicense);
+		return Create(reverseGeoCodeProviderOptional: reverseGeocodeProvider, hasPaidLicenseOptional: hasPaidLicense);
 	}
 }

--- a/tests/Fakes/Options/InfoOptionsFakes.cs
+++ b/tests/Fakes/Options/InfoOptionsFakes.cs
@@ -14,10 +14,9 @@ public static class InfoOptionsFakes
 		return new InfoOptions(outputFolder, sourceFolderPath);
 	}
 
-	public static InfoOptions WithNoExifDataAction(string sourceFolderPath, InfoNoPhotoTakenDateAction noPhotoDateTimeTakenAction = InfoNoPhotoTakenDateAction.Continue,
-		InfoNoCoordinateAction noCoordinateAction = InfoNoCoordinateAction.Continue)
+	public static InfoOptions WithPreventAction(string sourceFolderPath, InfoInvalidFormatAction invalidFormatAction, InfoNoPhotoTakenDateAction noPhotoDateTimeTakenAction, InfoNoCoordinateAction noCoordinateAction)
 	{
-		return new InfoOptions(OutputFolder, sourceFolderPath, noPhotoTakenDateAction: noPhotoDateTimeTakenAction, noCoordinateAction: noCoordinateAction);
+		return new InfoOptions(OutputFolder, sourceFolderPath, invalidFileFormatAction: invalidFormatAction, noPhotoTakenDateAction: noPhotoDateTimeTakenAction, noCoordinateAction: noCoordinateAction);
 	}
 
 	public static InfoOptions WithValidReverseGeocodeService(string outputFolder, string sourceFolderPath)

--- a/tests/Fakes/PhotoFakes.cs
+++ b/tests/Fakes/PhotoFakes.cs
@@ -58,6 +58,11 @@ public static class PhotoFakes
 		return Create();
 	}
 
+	public static Photo ValidFileWithDay(int day)
+	{
+		return Create(takenDate: DateTimeFakes.WithDay(day));
+	}
+
 	public static Photo NoDateWithTargetRelativeDirectoryPath(string targetRelativeDirectoryPath)
 	{
 		return Create(targetRelativeDirectoryPath: targetRelativeDirectoryPath);
@@ -126,10 +131,20 @@ public static class PhotoFakes
 		return Create(fileNameWithExtension, targetRelativeDirectoryPath: targetRelativeDirectoryPath, newName: newName);
 	}
 
-	public static Photo WithValidFilePath(string sourcePath, string fileNameWithExtension, ExifData photoExifData, string targetRelativeDirectoryPath)
+	public static Photo WithInvalidFileFormat()
 	{
-		return Create(fileNameWithExtension, photoExifData.TakenDate, photoExifData.Coordinate, targetRelativeDirectoryPath, sourcePath: sourcePath,
-			reverseGeocodes: photoExifData.ReverseGeocodes);
+		return InvalidFileFormat();
+	}
+
+	public static Photo WithValidFilePathInvalidFileFormat(string sourcePath, string fileNameWithExtension, string targetRelativeDirectoryPath)
+	{
+		return InvalidFileFormat(fileNameWithExtension, targetRelativeDirectoryPath: targetRelativeDirectoryPath, sourcePath: sourcePath);
+	}
+
+	public static Photo WithValidFilePathAndExifData(string sourcePath, string fileNameWithExtension, ExifData? photoExifData, string targetRelativeDirectoryPath)
+	{
+		return Create(fileNameWithExtension, photoExifData?.TakenDate, photoExifData?.Coordinate, targetRelativeDirectoryPath, sourcePath: sourcePath,
+			reverseGeocodes: photoExifData?.ReverseGeocodes);
 	}
 
 	public static Photo WithSha1Hash(string fileNameWithExtension, string sha1Hash, string? targetRelativeDirectoryPath = "")
@@ -140,11 +155,21 @@ public static class PhotoFakes
 	public static Photo Create(string? fileNameWithExtension = null, DateTime? takenDate = null, Coordinate? coordinate = null, string? targetRelativeDirectoryPath = null, string? newName = null,
 		IEnumerable<string>? reverseGeocodes = null, string? sourcePath = null, string? sha1Hash = null)
 	{
+		var exifData = ExifDataFakes.Create(takenDate, coordinate, reverseGeocodes?.ToList());
+		return CreateWithExifData(exifData, fileNameWithExtension, targetRelativeDirectoryPath, newName, sourcePath, sha1Hash);
+	}
+
+	private static Photo InvalidFileFormat(string? fileNameWithExtension = null, string? targetRelativeDirectoryPath = null, string? newName = null, string? sourcePath = null, string? sha1Hash = null)
+	{
+		return CreateWithExifData(null, fileNameWithExtension, targetRelativeDirectoryPath, newName, sourcePath, sha1Hash);
+	}
+
+	private static Photo CreateWithExifData(ExifData? exifData, string? fileNameWithExtension = null, string? targetRelativeDirectoryPath = null, string? newName = null, string? sourcePath = null, string? sha1Hash = null)
+	{
 		sourcePath ??= "source-path";
 		fileNameWithExtension ??= "dummy.jpg";
 		targetRelativeDirectoryPath ??= string.Empty;
 		var mockFileInfo = new MockFileInfo(new MockFileSystem(), Path.Combine(sourcePath, fileNameWithExtension));
-		var exifData = ExifDataFakes.Create(takenDate, coordinate, reverseGeocodes?.ToList());
 		var photo = new Photo(mockFileInfo, exifData, targetRelativeDirectoryPath) { NewName = newName };
 		if (sha1Hash != null)
 			photo.Sha1Hash = sha1Hash;

--- a/tests/Fakes/ToolOptionFakes.cs
+++ b/tests/Fakes/ToolOptionFakes.cs
@@ -19,6 +19,7 @@ public static class ToolOptionFakes
 	public const string DayRangeSeparator = "-";
 	public const string SameNameNumberSeparator = "-";
 
+	public const string PhotoFormatInvalidFolderName = "invalid-photo-format";
 	public const string NoPhotoTakenDateFolderName = "no-photo-taken-date";
 	public const string NoAddressFolderName = "no-address";
 	public const string NoAddressAndPhotoTakenDateFolderName = "no-address-and-no-photo-taken-date";
@@ -43,6 +44,7 @@ public static class ToolOptionFakes
 			DayRangeSeparator = DayRangeSeparator,
 			SameNameNumberSeparator = SameNameNumberSeparator,
 
+			PhotoFormatInvalidFolderName = PhotoFormatInvalidFolderName,
 			NoPhotoTakenDateFolderName = NoPhotoTakenDateFolderName,
 			NoAddressFolderName = NoAddressFolderName,
 			NoAddressAndPhotoTakenDateFolderName = NoAddressAndPhotoTakenDateFolderName,

--- a/tests/IntegrationTests/FileSystem/CopyServiceFileSystemTests.cs
+++ b/tests/IntegrationTests/FileSystem/CopyServiceFileSystemTests.cs
@@ -85,7 +85,7 @@ public class CopyServiceFileSystemTests
 	[MemberData(nameof(PhotoDateTakenData))]
 	[MemberData(nameof(CoordinateAndReverseGeocodeData))]
 	[MemberData(nameof(MixedData))]
-	public async Task CsvOutput_Writes_File_And_And_Verify_PhotoCsv_Model_Matched_With_Reading_Output_File(Dictionary<string, ExifData> exifData,
+	public async Task CsvOutput_Writes_File_And_And_Verify_PhotoCsv_Model_Matched_With_Reading_Output_File(Dictionary<string, ExifData?> exifData,
 		List<PhotoCsv> expectedPhotoCsvModels)
 	{
 		var outputCsvPath = MockFileSystemHelper.Path("/output.csv");

--- a/tests/IntegrationTests/PackageTests/CommandLineParserIntegrationTests.cs
+++ b/tests/IntegrationTests/PackageTests/CommandLineParserIntegrationTests.cs
@@ -10,7 +10,7 @@ public class CommandLineParserIntegrationTests
 			CommandLineArgumentsFakes.CopyBuildCommandLineOptions("/home/user/Desktop/path1", "/home/user/Desktop/output1", NamingStyleFakes.Valid(),
 				FolderProcessTypeFakes.Valid(), NumberNamingTextStyleFakes.Valid(), CopyNoPhotoTakenDateAction.PreventProcess, CopyNoCoordinateAction.PreventProcess, true),
 			new CopyOptions("/home/user/Desktop/path1", NamingStyleFakes.Valid(), FolderProcessTypeFakes.Valid(),
-				NumberNamingTextStyleFakes.Valid(), CopyNoPhotoTakenDateAction.PreventProcess, CopyNoCoordinateAction.PreventProcess, "/home/user/Desktop/output1", true)
+				NumberNamingTextStyleFakes.Valid(), CopyInvalidFormatAction.PreventProcess, CopyNoPhotoTakenDateAction.PreventProcess, CopyNoCoordinateAction.PreventProcess, "/home/user/Desktop/output1", true)
 		}
 	};
 

--- a/tests/IntegrationTests/PackageTests/FluentValidation/ToolOptionsFluentValidationTests.cs
+++ b/tests/IntegrationTests/PackageTests/FluentValidation/ToolOptionsFluentValidationTests.cs
@@ -86,6 +86,7 @@ public class ToolOptionsFluentValidationTests : BaseFluentValidationTests<ToolOp
 	[InlineData(nameof(ToolOptions.FolderAppendSeparator))]
 	[InlineData(nameof(ToolOptions.DayRangeSeparator))]
 	[InlineData(nameof(ToolOptions.SameNameNumberSeparator))]
+	[InlineData(nameof(ToolOptions.PhotoFormatInvalidFolderName))]
 	[InlineData(nameof(ToolOptions.NoPhotoTakenDateFolderName))]
 	[InlineData(nameof(ToolOptions.NoAddressFolderName))]
 	[InlineData(nameof(ToolOptions.NoAddressAndPhotoTakenDateFolderName))]

--- a/tests/IntegrationTests/PackageTests/MetadataExtractorIntegrationTests.cs
+++ b/tests/IntegrationTests/PackageTests/MetadataExtractorIntegrationTests.cs
@@ -29,7 +29,7 @@ public class PhotoExifParserIntegrationTests
 	public void Photo_Taken_Date_Equals_To_Expected(string filePath, DateTime? dateExpected)
 	{
 		var photoExifData = _sut.Parse(filePath, true, false);
-		photoExifData.TakenDate.Should().Be(dateExpected);
+		photoExifData?.TakenDate.Should().Be(dateExpected);
 	}
 
 	[Theory]
@@ -37,7 +37,7 @@ public class PhotoExifParserIntegrationTests
 	public void Coordinate_Equals_To_Expected(string filePath, Coordinate? coordinateExpected)
 	{
 		var exifData = _sut.Parse(filePath, false, true);
-		exifData.Coordinate.Should().Be(coordinateExpected);
+		exifData?.Coordinate.Should().Be(coordinateExpected);
 	}
 
 	[Theory]

--- a/tests/UnitTests/Services/DirectoryGrouperServiceUnitTests.cs
+++ b/tests/UnitTests/Services/DirectoryGrouperServiceUnitTests.cs
@@ -2,28 +2,28 @@ namespace PhotoCli.Tests.UnitTests.Services;
 
 public class DirectoryGrouperServiceUnitTests
 {
-	#region SubFoldersPreserveFolderHierarchy
+	#region Shared
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesLocatedInSourceRootShouldGroupedInRootPath = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllValidFilesLocatedInSourceRootShouldGroupedInRootPath = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithDay(1) },
 			},
 			new Dictionary<string, List<Photo>>
 			{
 				{
-					string.Empty,
+					RootTargetRelativePath,
 					new List<Photo>
 					{
-						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), string.Empty),
+						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), RootTargetRelativePath),
 					}
 				}
 			}
 		},
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithDay(1) },
 				{ SourceRootPath("f2.jpg"), ExifDataFakes.WithDay(2) }
@@ -31,21 +31,55 @@ public class DirectoryGrouperServiceUnitTests
 			new Dictionary<string, List<Photo>>
 			{
 				{
-					string.Empty,
+					RootTargetRelativePath,
 					new List<Photo>
 					{
-						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), string.Empty),
-						SourceRootPhotoInfo("f2.jpg", ExifDataFakes.WithDay(2), string.Empty),
+						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), RootTargetRelativePath),
+						SourceRootPhotoInfo("f2.jpg", ExifDataFakes.WithDay(2), RootTargetRelativePath),
 					}
 				}
 			}
 		}
 	};
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesLocatedInSubFolderShouldGroupedInTheirRelativePath = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> SomeValidFilesSomeInvalidFilesShouldGroupedInRootPath = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1) },
+				{ SourceRootPath("f2-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceRootPath("f3-root-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() },
+				{ SourceRootPath("f4-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceRootPath("f5-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1), RootTargetRelativePath),
+						SourceRootPhotoInfo("f2-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), RootTargetRelativePath),
+						SourceRootPhotoInfo("f3-root-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(), RootTargetRelativePath),
+						SourceRootPhotoInfo("f4-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(), RootTargetRelativePath),
+						SourceRootPhotoInfoInvalidFileFormat("f5-root-invalid-file-format.jpg", RootTargetRelativePath),
+					}
+				},
+			}
+		},
+	};
+
+	#endregion
+
+	#region SubFoldersPreserveFolderHierarchy
+
+	#region Without Move Action
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllFilesLocatedInSubFolderShouldGroupedInTheirRelativePath = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f1.jpg"), ExifDataFakes.WithDay(1) },
 			},
@@ -61,7 +95,7 @@ public class DirectoryGrouperServiceUnitTests
 			}
 		},
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f1.jpg"), ExifDataFakes.WithDay(1) },
 				{ SourceSubPath("f2.jpg"), ExifDataFakes.WithDay(2) }
@@ -80,10 +114,10 @@ public class DirectoryGrouperServiceUnitTests
 		}
 	};
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> FilesLocatedInRootAndSubFoldersShouldGroupedInTheirRelativePath = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> FilesLocatedInRootAndSubFoldersShouldGroupedInTheirRelativePath = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDay(1) },
 				{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithDay(2) }
@@ -91,10 +125,10 @@ public class DirectoryGrouperServiceUnitTests
 			new Dictionary<string, List<Photo>>
 			{
 				{
-					string.Empty,
+					RootTargetRelativePath,
 					new List<Photo>
 					{
-						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDay(1), string.Empty),
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDay(1), RootTargetRelativePath),
 					}
 				},
 				{
@@ -108,191 +142,392 @@ public class DirectoryGrouperServiceUnitTests
 		}
 	};
 
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> FilesWithNoExifDataOrInvalidFormatStaysInTheirSourceFolders = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1) },
+				{ SourceRootPath("f2-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceRootPath("f3-root-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() },
+				{ SourceRootPath("f4-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceRootPath("f5-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+				{ SourceSubPath("f6-sub.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2) },
+				{ SourceSubPath("f7-sub-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceSubPath("f8-sub-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() },
+				{ SourceSubPath("f9-sub-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceSubPath("f10-sub-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() }
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1), RootTargetRelativePath),
+						SourceRootPhotoInfo("f2-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), RootTargetRelativePath),
+						SourceRootPhotoInfo("f3-root-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(), RootTargetRelativePath),
+						SourceRootPhotoInfo("f4-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(), RootTargetRelativePath),
+						SourceRootPhotoInfoInvalidFileFormat("f5-root-invalid-file-format.jpg", RootTargetRelativePath),
+					}
+				},
+				{
+					SubPath,
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f6-sub.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2), SubPath),
+						SourceSubPhotoInfo("f7-sub-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), SubPath),
+						SourceSubPhotoInfo("f8-sub-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(), SubPath),
+						SourceSubPhotoInfo("f9-sub-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(), SubPath),
+						SourceSubPhotoInfoInvalidFileFormat("f10-sub-invalid-file-format.jpg", SubPath),
+					}
+				},
+			}
+		},
+	};
+
 	[Theory]
-	[MemberData(nameof(AllFilesLocatedInSourceRootShouldGroupedInRootPath))]
+	[MemberData(nameof(AllValidFilesLocatedInSourceRootShouldGroupedInRootPath))]
+	[MemberData(nameof(SomeValidFilesSomeInvalidFilesShouldGroupedInRootPath))]
 	[MemberData(nameof(AllFilesLocatedInSubFolderShouldGroupedInTheirRelativePath))]
 	[MemberData(nameof(FilesLocatedInRootAndSubFoldersShouldGroupedInTheirRelativePath))]
-	public void SubFoldersPreserveFolderHierarchy_GroupFilesByRelativeDirectory_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
-		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
+	[MemberData(nameof(FilesWithNoExifDataOrInvalidFormatStaysInTheirSourceFolders))]
+
+	public void SubFoldersPreserveFolderHierarchy_NoMoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath, Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.SubFoldersPreserveFolderHierarchy, null, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
 	}
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>, bool, bool>
-		FilesNotHavePhotoTakenDateShouldGroupedInSubFolderIfNoPhotoDateTimeTakenGroupedInSubFolderIsTrue = new()
-		{
-			{
-				new Dictionary<string, ExifData>
-				{
-					{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDay(1) },
-					{ SourceRootPath("f1-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
-					{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithDay(2) },
-					{ SourceSubPath("f2-sub-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() }
-				},
-				new Dictionary<string, List<Photo>>
-				{
-					{
-						string.Empty,
-						new List<Photo>
-						{
-							SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDay(1), string.Empty),
-						}
-					},
-					{
-						ToolOptionFakes.NoPhotoTakenDateFolderName,
-						new List<Photo>
-						{
-							SourceRootPhotoInfo("f1-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), ToolOptionFakes.NoPhotoTakenDateFolderName),
-						}
-					},
-					{
-						SubPath,
-						new List<Photo>
-						{
-							SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithDay(2), SubPath),
-						}
-					},
-					{
-						MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoPhotoTakenDateFolderName),
-						new List<Photo>
-						{
-							SourceSubPhotoInfo("f2-sub-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(),
-								MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoPhotoTakenDateFolderName)),
-						}
-					},
-				},
-				true,
-				false
-			}
-		};
+	#endregion
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>, bool, bool> FilesNotHaveGeocodeShouldGroupedInSubFolderIfNoReverseGeocodeGroupedInSubFolderIsTrue =
-		new()
-		{
-			{
-				new Dictionary<string, ExifData>
-				{
-					{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(1) },
-					{ SourceRootPath("f1-root-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() },
-					{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(2) },
-					{ SourceSubPath("f2-sub-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() }
-				},
-				new Dictionary<string, List<Photo>>
-				{
-					{
-						string.Empty,
-						new List<Photo>
-						{
-							SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithReverseGeocodeSampleId(1), string.Empty),
-						}
-					},
-					{
-						ToolOptionFakes.NoAddressFolderName,
-						new List<Photo>
-						{
-							SourceRootPhotoInfo("f1-root-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(), ToolOptionFakes.NoAddressFolderName),
-						}
-					},
-					{
-						SubPath,
-						new List<Photo>
-						{
-							SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithReverseGeocodeSampleId(2), SubPath),
-						}
-					},
-					{
-						MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressFolderName),
-						new List<Photo>
-						{
-							SourceSubPhotoInfo("f2-sub-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(),
-								MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressFolderName)),
-						}
-					},
-				},
-				false,
-				true
-			}
-		};
+	#region With Move Action
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>, bool, bool>
-		FilesNotHaveGeocodeAndPhotoTakenDateShouldGroupedInSubFolderIfNoReverseGeocodeGroupedInSubFolderAndNoPhotoDateTimeTakenGroupedInSubFolderIsTrue = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FilesNotHavePhotoTakenDateShouldGroupedInSubFolderIfNoPhotoDateTimeTakenGroupedInSubFolderIsTrue = new()
+	{
 		{
+			new Dictionary<string, ExifData?>
 			{
-				new Dictionary<string, ExifData>
+				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDay(1) },
+				{ SourceRootPath("f1-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithDay(2) },
+				{ SourceSubPath("f2-sub-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() }
+			},
+			new Dictionary<string, List<Photo>>
+			{
 				{
-					{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1) },
-					{ SourceRootPath("f1-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
-					{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2) },
-					{ SourceSubPath("f2-sub-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() }
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDay(1), RootTargetRelativePath),
+					}
 				},
-				new Dictionary<string, List<Photo>>
 				{
+					ToolOptionFakes.NoPhotoTakenDateFolderName,
+					new List<Photo>
 					{
-						string.Empty,
-						new List<Photo>
-						{
-							SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1), string.Empty),
-						}
-					},
-					{
-						ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName,
-						new List<Photo>
-						{
-							SourceRootPhotoInfo("f1-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(),
-								ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName),
-						}
-					},
-					{
-						SubPath,
-						new List<Photo>
-						{
-							SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2), SubPath),
-						}
-					},
-					{
-						MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName),
-						new List<Photo>
-						{
-							SourceSubPhotoInfo("f2-sub-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(),
-								MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName)),
-						}
-					},
+						SourceRootPhotoInfo("f1-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), ToolOptionFakes.NoPhotoTakenDateFolderName),
+					}
 				},
-				true,
-				true
-			}
-		};
+				{
+					SubPath,
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithDay(2), SubPath),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoPhotoTakenDateFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f2-sub-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(),
+							MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoPhotoTakenDateFolderName)),
+					}
+				},
+			},
+			false,
+			true,
+			false
+		}
+	};
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FilesNotHaveGeocodeShouldGroupedInSubFolderIfNoReverseGeocodeGroupedInSubFolderIsTrue = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(1) },
+				{ SourceRootPath("f1-root-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() },
+				{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(2) },
+				{ SourceSubPath("f2-sub-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() }
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithReverseGeocodeSampleId(1), RootTargetRelativePath),
+					}
+				},
+				{
+					ToolOptionFakes.NoAddressFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(), ToolOptionFakes.NoAddressFolderName),
+					}
+				},
+				{
+					SubPath,
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithReverseGeocodeSampleId(2), SubPath),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f2-sub-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(),
+							MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressFolderName)),
+					}
+				},
+			},
+			false,
+			false,
+			true
+		}
+	};
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FilesNotHaveGeocodeAndPhotoTakenDateShouldGroupedInSubFolderIfNoReverseGeocodeGroupedInSubFolderAndNoPhotoDateTimeTakenGroupedInSubFolderIsTrue = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1) },
+				{ SourceRootPath("f1-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2) },
+				{ SourceSubPath("f2-sub-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() }
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1), RootTargetRelativePath),
+					}
+				},
+				{
+					ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(),
+							ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName),
+					}
+				},
+				{
+					SubPath,
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2), SubPath),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f2-sub-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(),
+							MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName)),
+					}
+				},
+			},
+			false,
+			true,
+			true
+		}
+	};
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FilesHasInvalidFormatShouldGroupedInSubFolderIfInvalidFileFormatGroupedInSubFolderIsTrue = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1) },
+				{ SourceRootPath("f1-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+				{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2) },
+				{ SourceSubPath("f2-sub-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() }
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1), RootTargetRelativePath),
+					}
+				},
+				{
+					ToolOptionFakes.PhotoFormatInvalidFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfoInvalidFileFormat("f1-root-invalid-file-format.jpg", ToolOptionFakes.PhotoFormatInvalidFolderName),
+					}
+				},
+				{
+					SubPath,
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2), SubPath),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.PhotoFormatInvalidFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfoInvalidFileFormat("f2-sub-invalid-file-format.jpg", MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.PhotoFormatInvalidFolderName)),
+					}
+				},
+			},
+			true,
+			false,
+			false
+		}
+	};
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FilesWithNoExifDataOrInvalidFormatGoesIntoItsRelativeSubFolder = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1) },
+				{ SourceRootPath("f2-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceRootPath("f3-root-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() },
+				{ SourceRootPath("f4-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceRootPath("f5-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+				{ SourceSubPath("f6-sub.jpg"), ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2) },
+				{ SourceSubPath("f7-sub-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceSubPath("f8-sub-no-reverse-geocode.jpg"), ExifDataFakes.WithNoReverseGeocode() },
+				{ SourceSubPath("f9-sub-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceSubPath("f10-sub-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() }
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(1, 1), RootTargetRelativePath),
+					}
+				},
+				{
+					ToolOptionFakes.NoPhotoTakenDateFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f2-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), ToolOptionFakes.NoPhotoTakenDateFolderName),
+					}
+				},
+				{
+					ToolOptionFakes.NoAddressFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f3-root-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(), ToolOptionFakes.NoAddressFolderName),
+					}
+				},
+				{
+					ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f4-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(),
+							ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName),
+					}
+				},
+				{
+					ToolOptionFakes.PhotoFormatInvalidFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfoInvalidFileFormat("f5-root-invalid-file-format.jpg", ToolOptionFakes.PhotoFormatInvalidFolderName),
+					}
+				},
+				{
+					SubPath,
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f6-sub.jpg", ExifDataFakes.WithDayAndReverseGeocodeSampleId(2, 2), SubPath),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoPhotoTakenDateFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f7-sub-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(),
+							MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoPhotoTakenDateFolderName)),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f8-sub-no-reverse-geocode.jpg", ExifDataFakes.WithNoReverseGeocode(),
+							MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressFolderName)),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfo("f9-sub-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(),
+							MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.NoAddressAndPhotoTakenDateFolderName)),
+					}
+				},
+				{
+					MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.PhotoFormatInvalidFolderName),
+					new List<Photo>
+					{
+						SourceSubPhotoInfoInvalidFileFormat("f10-sub-invalid-file-format.jpg", MockFileSystemHelper.RelativePath(SubPath, ToolOptionFakes.PhotoFormatInvalidFolderName)),
+					}
+				},
+			},
+			true,
+			true,
+			true
+		}
+	};
 
 	[Theory]
 	[MemberData(nameof(FilesNotHavePhotoTakenDateShouldGroupedInSubFolderIfNoPhotoDateTimeTakenGroupedInSubFolderIsTrue))]
 	[MemberData(nameof(FilesNotHaveGeocodeShouldGroupedInSubFolderIfNoReverseGeocodeGroupedInSubFolderIsTrue))]
 	[MemberData(nameof(FilesNotHaveGeocodeAndPhotoTakenDateShouldGroupedInSubFolderIfNoReverseGeocodeGroupedInSubFolderAndNoPhotoDateTimeTakenGroupedInSubFolderIsTrue))]
-	public void SubFoldersPreserveFolderHierarchy_GroupFilesByRelativeDirectory_Be_EquivalentTo_With_No_Action_Parameter(Dictionary<string, ExifData> photoExifDataByFilePath,
-		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory, bool noPhotoDateTimeTakenGroupedInSubFolder, bool noReverseGeocodeGroupedInSubFolder)
+	[MemberData(nameof(FilesHasInvalidFormatShouldGroupedInSubFolderIfInvalidFileFormatGroupedInSubFolderIsTrue))]
+	[MemberData(nameof(FilesWithNoExifDataOrInvalidFormatGoesIntoItsRelativeSubFolder))]
+	public void SubFoldersPreserveFolderHierarchy_SelectedMoveActionForSubFolders_Should_Move_To_Its_Relative_Folder(Dictionary<string, ExifData?> photoExifDataByFilePath,
+		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory, bool invalidFileFormatGroupedInSubFolder, bool noPhotoDateTimeTakenGroupedInSubFolder, bool noReverseGeocodeGroupedInSubFolder)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.SubFoldersPreserveFolderHierarchy, null, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory,
-			noPhotoDateTimeTakenGroupedInSubFolder, noReverseGeocodeGroupedInSubFolder);
+			invalidFileFormatGroupedInSubFolder, noPhotoDateTimeTakenGroupedInSubFolder, noReverseGeocodeGroupedInSubFolder);
 	}
+
+	#endregion
 
 	#endregion
 
 	#region Single
 
 	[Theory]
-	[MemberData(nameof(AllFilesLocatedInSourceRootShouldGroupedInRootPath))]
-	public void Single_GroupFilesByRelativeDirectory_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
+	[MemberData(nameof(AllValidFilesLocatedInSourceRootShouldGroupedInRootPath))]
+	[MemberData(nameof(SomeValidFilesSomeInvalidFilesShouldGroupedInRootPath))]
+	public void Single_GroupFilesByRelativeDirectory_Be_EquivalentTo(Dictionary<string, ExifData?> photoExifDataByFilePath,
 		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.Single, null, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
 	}
 
-	public static TheoryData<Dictionary<string, ExifData>> SendingFilesLocatedOnSubFoldersOnSingleFolderProcessTypeShouldThrowPhotoOrganizerToolExceptionData = new()
+	public static TheoryData<Dictionary<string, ExifData?>> SendingFilesLocatedOnSubFoldersOnSingleFolderProcessTypeShouldThrowPhotoOrganizerToolExceptionData = new()
 	{
-		new Dictionary<string, ExifData>
+		new Dictionary<string, ExifData?>
 		{
 			{ SourceSubPath("f-sub.jpg"), ExifDataFakes.WithDay(2) }
 		},
-		new Dictionary<string, ExifData>
+		new Dictionary<string, ExifData?>
 		{
 			{ SourceRootPath("f-root.jpg"), ExifDataFakes.WithDay(1) },
 			{ SourceSubPath("f-sub.jpg"), ExifDataFakes.WithDay(2) }
@@ -301,7 +536,7 @@ public class DirectoryGrouperServiceUnitTests
 
 	[Theory]
 	[MemberData(nameof(SendingFilesLocatedOnSubFoldersOnSingleFolderProcessTypeShouldThrowPhotoOrganizerToolExceptionData))]
-	public void Sending_Files_Located_On_Sub_Folders_On_Single_FolderProcessType_Should_Throw_PhotoOrganizerToolException(Dictionary<string, ExifData> photoExifDataByFilePath)
+	public void Sending_Files_Located_On_Sub_Folders_On_Single_FolderProcessType_Should_Throw_PhotoOrganizerToolException(Dictionary<string, ExifData?> photoExifDataByFilePath)
 	{
 		Assert.Throws<PhotoCliException>(() =>
 			GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.Single, null, photoExifDataByFilePath, new Dictionary<string, List<Photo>>())
@@ -312,28 +547,28 @@ public class DirectoryGrouperServiceUnitTests
 
 	#region FlattenAllSubFolders
 
-	#region No FlattenType
+	#region No Group By Folder Type
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesLocatedInSubFolderShouldFlattenedIntoRootPath = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllFilesLocatedInSubFolderShouldFlattenedIntoRootPath = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f1.jpg"), ExifDataFakes.WithDay(1) },
 			},
 			new Dictionary<string, List<Photo>>
 			{
 				{
-					string.Empty,
+					RootTargetRelativePath,
 					new List<Photo>
 					{
-						SourceSubPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), string.Empty),
+						SourceSubPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), RootTargetRelativePath),
 					}
 				}
 			}
 		},
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f1.jpg"), ExifDataFakes.WithDay(1) },
 				{ SourceSubPath("f2.jpg"), ExifDataFakes.WithDay(2) }
@@ -341,21 +576,21 @@ public class DirectoryGrouperServiceUnitTests
 			new Dictionary<string, List<Photo>>
 			{
 				{
-					string.Empty,
+					RootTargetRelativePath,
 					new List<Photo>
 					{
-						SourceSubPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), string.Empty),
-						SourceSubPhotoInfo("f2.jpg", ExifDataFakes.WithDay(2), string.Empty),
+						SourceSubPhotoInfo("f1.jpg", ExifDataFakes.WithDay(1), RootTargetRelativePath),
+						SourceSubPhotoInfo("f2.jpg", ExifDataFakes.WithDay(2), RootTargetRelativePath),
 					}
 				}
 			}
 		}
 	};
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> FilesLocatedInRootAndSubFoldersShouldFlattenedIntoRootPath = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> FilesLocatedInRootAndSubFoldersShouldFlattenedIntoRootPath = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1-root.jpg"), ExifDataFakes.WithDay(1) },
 				{ SourceSubPath("f2-sub.jpg"), ExifDataFakes.WithDay(2) }
@@ -363,11 +598,11 @@ public class DirectoryGrouperServiceUnitTests
 			new Dictionary<string, List<Photo>>
 			{
 				{
-					string.Empty,
+					RootTargetRelativePath,
 					new List<Photo>
 					{
-						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDay(1), string.Empty),
-						SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithDay(2), string.Empty),
+						SourceRootPhotoInfo("f1-root.jpg", ExifDataFakes.WithDay(1), RootTargetRelativePath),
+						SourceSubPhotoInfo("f2-sub.jpg", ExifDataFakes.WithDay(2), RootTargetRelativePath),
 					}
 				},
 			}
@@ -375,11 +610,11 @@ public class DirectoryGrouperServiceUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(AllFilesLocatedInSourceRootShouldGroupedInRootPath))]
+	[MemberData(nameof(AllValidFilesLocatedInSourceRootShouldGroupedInRootPath))]
+	[MemberData(nameof(SomeValidFilesSomeInvalidFilesShouldGroupedInRootPath))]
 	[MemberData(nameof(AllFilesLocatedInSubFolderShouldFlattenedIntoRootPath))]
 	[MemberData(nameof(FilesLocatedInRootAndSubFoldersShouldFlattenedIntoRootPath))]
-	public void FlattenAllSubFolders_GroupFilesByRelativeDirectory_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
-		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
+	public void FlattenAllSubFolders_NoMoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath, Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.FlattenAllSubFolders, null, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
 	}
@@ -388,10 +623,10 @@ public class DirectoryGrouperServiceUnitTests
 
 	#region Year
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoYear = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllFilesThatHasPhotoTakenDateFlattenedAndGroupIntoYearFolders = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithYear(2001) },
 			},
@@ -407,7 +642,7 @@ public class DirectoryGrouperServiceUnitTests
 			}
 		},
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1-1.jpg"), ExifDataFakes.WithYear(2001) },
 				{ SourceSubPath("f2.jpg"), ExifDataFakes.WithYear(2002) },
@@ -435,8 +670,8 @@ public class DirectoryGrouperServiceUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(AllFilesFlattenedAndGroupIntoYear))]
-	public void FlattenAllSubFoldersThenGroupByYear_GroupFilesByRelativeDirectory_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
+	[MemberData(nameof(AllFilesThatHasPhotoTakenDateFlattenedAndGroupIntoYearFolders))]
+	public void FlattenAllSubFolders_GroupBy_Year_NoMoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath,
 		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.FlattenAllSubFolders, GroupByFolderType.Year, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
@@ -446,10 +681,10 @@ public class DirectoryGrouperServiceUnitTests
 
 	#region YearMonth
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoYearMonth = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoYearMonth = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithMonth(1) },
 			},
@@ -465,7 +700,7 @@ public class DirectoryGrouperServiceUnitTests
 			}
 		},
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f1-1.jpg"), ExifDataFakes.WithMonth(1) },
 				{ SourceRootPath("f2.jpg"), ExifDataFakes.WithMonth(2) },
@@ -494,7 +729,7 @@ public class DirectoryGrouperServiceUnitTests
 
 	[Theory]
 	[MemberData(nameof(AllFilesFlattenedAndGroupIntoYearMonth))]
-	public void FlattenAllSubFoldersThenGroupByYearMonth_GroupFilesByRelativeDirectory_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
+	public void FlattenAllSubFolders_GroupBy_YearMonth_NoMoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath,
 		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.FlattenAllSubFolders, GroupByFolderType.YearMonth, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
@@ -504,10 +739,10 @@ public class DirectoryGrouperServiceUnitTests
 
 	#region YearMonthDay
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoYearMonthDay = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoYearMonthDay = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f1.jpg"), ExifDataFakes.WithDay(1) },
 			},
@@ -523,7 +758,7 @@ public class DirectoryGrouperServiceUnitTests
 			}
 		},
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceRootPath("f1-1.jpg"), ExifDataFakes.WithDay(1) },
 				{ SourceSubPath("f2.jpg"), ExifDataFakes.WithDay(2) },
@@ -552,7 +787,7 @@ public class DirectoryGrouperServiceUnitTests
 
 	[Theory]
 	[MemberData(nameof(AllFilesFlattenedAndGroupIntoYearMonthDay))]
-	public void FlattenAllSubFoldersThenGroupByYearMonthDay_GroupFilesByRelativeDirectory_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
+	public void FlattenAllSubFolders_GroupBy_YearMonthDay_NoMoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath,
 		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.FlattenAllSubFolders, GroupByFolderType.YearMonthDay, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
@@ -562,10 +797,10 @@ public class DirectoryGrouperServiceUnitTests
 
 	#region AddressFlat
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoAddressFlat = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoAddressFlat = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f2-1.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(2) },
 				{ SourceSubPath("f1.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(1) },
@@ -594,7 +829,7 @@ public class DirectoryGrouperServiceUnitTests
 
 	[Theory]
 	[MemberData(nameof(AllFilesFlattenedAndGroupIntoAddressFlat))]
-	public void FlattenAllSubFolders_Then_GroupByFolder_Type_AddressFlat_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
+	public void FlattenAllSubFolders_GroupBy_AddressFlat_NoMoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath,
 		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.FlattenAllSubFolders, GroupByFolderType.AddressFlat, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
@@ -604,10 +839,10 @@ public class DirectoryGrouperServiceUnitTests
 
 	#region AddressHierarchy
 
-	public static TheoryData<Dictionary<string, ExifData>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoAddressHierarchy = new()
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>> AllFilesFlattenedAndGroupIntoAddressHierarchy = new()
 	{
 		{
-			new Dictionary<string, ExifData>
+			new Dictionary<string, ExifData?>
 			{
 				{ SourceSubPath("f2-1.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(2) },
 				{ SourceSubPath("f1.jpg"), ExifDataFakes.WithReverseGeocodeSampleId(1) },
@@ -636,10 +871,178 @@ public class DirectoryGrouperServiceUnitTests
 
 	[Theory]
 	[MemberData(nameof(AllFilesFlattenedAndGroupIntoAddressHierarchy))]
-	public void FlattenAllSubFolders_Then_GroupByFolder_Type_AddressHierarchy_Be_EquivalentTo(Dictionary<string, ExifData> photoExifDataByFilePath,
+	public void FlattenAllSubFolders_GroupBy_AddressHierarchy_NoMoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath,
 		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory)
 	{
 		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.FlattenAllSubFolders, GroupByFolderType.AddressHierarchy, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory);
+	}
+
+	#endregion
+
+	#region No Exif Data, Invalid File Format - Move Action For Sub Folders
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FlattenedAndGroupIntoNoMoveActionForSubfoldersRootFolder = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithYear(2001) },
+				{ SourceRootPath("f2-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceRootPath("f3-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceRootPath("f4-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					DateTimeFakes.FormatYear(2001),
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithYear(2001), DateTimeFakes.FormatYear(2001)),
+					}
+				},
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f2-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), RootTargetRelativePath),
+						SourceRootPhotoInfo("f3-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(), RootTargetRelativePath),
+						SourceRootPhotoInfoInvalidFileFormat("f4-root-invalid-file-format.jpg", RootTargetRelativePath),
+					}
+				},
+			},
+			false,
+			false,
+			false
+		},
+	};
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FlattenedAndGroupIntoMoveActionForInvalidFilesInSubfolders = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithYear(2001) },
+				{ SourceRootPath("f2-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceRootPath("f3-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceRootPath("f4-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					DateTimeFakes.FormatYear(2001),
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithYear(2001), DateTimeFakes.FormatYear(2001)),
+					}
+				},
+				{
+					ToolOptionFakes.PhotoFormatInvalidFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfoInvalidFileFormat("f4-root-invalid-file-format.jpg", ToolOptionFakes.PhotoFormatInvalidFolderName),
+					}
+				},
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f2-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), RootTargetRelativePath),
+						SourceRootPhotoInfo("f3-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(), RootTargetRelativePath),
+					}
+				},
+			},
+			true,
+			false,
+			false
+		},
+	};
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FlattenedAndGroupIntoMoveActionForNoPhotoDateTimeTakenInSubFolders = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithYear(2001) },
+				{ SourceRootPath("f2-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceRootPath("f3-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceRootPath("f4-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					DateTimeFakes.FormatYear(2001),
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithYear(2001), DateTimeFakes.FormatYear(2001)),
+					}
+				},
+				{
+					ToolOptionFakes.NoPhotoTakenDateFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f2-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), ToolOptionFakes.NoPhotoTakenDateFolderName),
+						SourceRootPhotoInfo("f3-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(), ToolOptionFakes.NoPhotoTakenDateFolderName),
+						SourceRootPhotoInfoInvalidFileFormat("f4-root-invalid-file-format.jpg", ToolOptionFakes.NoPhotoTakenDateFolderName),
+					}
+				},
+			},
+			false,
+			true,
+			false
+		},
+	};
+
+	public static TheoryData<Dictionary<string, ExifData?>, Dictionary<string, List<Photo>>, bool, bool, bool> FlattenedAndGroupIntoMoveActionForNoReverseGeocodeGroupedInSubfolders = new()
+	{
+		{
+			new Dictionary<string, ExifData?>
+			{
+				{ SourceRootPath("f1.jpg"), ExifDataFakes.WithYearAndReverseGeocode(2001) },
+				{ SourceRootPath("f2-root-no-taken-date.jpg"), ExifDataFakes.WithNoPhotoTakenDate() },
+				{ SourceRootPath("f3-root-no-reverse-geocode-no-taken-date.jpg"), ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate() },
+				{ SourceRootPath("f4-root-invalid-file-format.jpg"), ExifDataFakes.WithInvalidFileFormat() },
+			},
+			new Dictionary<string, List<Photo>>
+			{
+				{
+					DateTimeFakes.FormatYear(2001),
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f1.jpg", ExifDataFakes.WithYearAndReverseGeocode(2001), DateTimeFakes.FormatYear(2001)),
+					}
+				},
+				{
+					ToolOptionFakes.NoAddressFolderName,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f3-root-no-reverse-geocode-no-taken-date.jpg", ExifDataFakes.WithNoReverseGeocodeAndNoTakenDate(), ToolOptionFakes.NoAddressFolderName),
+						SourceRootPhotoInfoInvalidFileFormat("f4-root-invalid-file-format.jpg", ToolOptionFakes.NoAddressFolderName),
+					}
+				},
+				{
+					RootTargetRelativePath,
+					new List<Photo>
+					{
+						SourceRootPhotoInfo("f2-root-no-taken-date.jpg", ExifDataFakes.WithNoPhotoTakenDate(), RootTargetRelativePath),
+					}
+				},
+			},
+			false,
+			false,
+			true
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(FlattenedAndGroupIntoNoMoveActionForSubfoldersRootFolder))]
+	[MemberData(nameof(FlattenedAndGroupIntoMoveActionForInvalidFilesInSubfolders))]
+	[MemberData(nameof(FlattenedAndGroupIntoMoveActionForNoPhotoDateTimeTakenInSubFolders))]
+	[MemberData(nameof(FlattenedAndGroupIntoMoveActionForNoReverseGeocodeGroupedInSubfolders))]
+	public void FlattenAllSubFolders_GroupBy_MoveActionForSubFolders_Should_Be_EquivalentTo_Expected(Dictionary<string, ExifData?> photoExifDataByFilePath,
+		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory, bool invalidFileFormatGroupedInSubFolder, bool noPhotoDateTimeTakenGroupedInSubFolder, bool noReverseGeocodeGroupedInSubFolder)
+	{
+		GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType.FlattenAllSubFolders, GroupByFolderType.Year, photoExifDataByFilePath, expectedGroupedPhotoInfosByRelativeDirectory,
+			invalidFileFormatGroupedInSubFolder, noPhotoDateTimeTakenGroupedInSubFolder, noReverseGeocodeGroupedInSubFolder);
 	}
 
 	#endregion
@@ -648,28 +1051,40 @@ public class DirectoryGrouperServiceUnitTests
 
 	#region Helpers
 
-	private static void GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType folderProcessType, GroupByFolderType? groupByFolderType, Dictionary<string, ExifData> photoExifDataByFilePath,
-		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory, bool noPhotoDateTimeTakenGroupedInSubFolder = false, bool noReverseGeocodeGroupedInSubFolder = false)
+	private static void GroupFilesByRelativeDirectoryBeEquivalentTo(FolderProcessType folderProcessType, GroupByFolderType? groupByFolderType, Dictionary<string, ExifData?> photoExifDataByFilePath,
+		Dictionary<string, List<Photo>> expectedGroupedPhotoInfosByRelativeDirectory, bool invalidFileFormatGroupedInSubFolder = false, bool noPhotoDateTimeTakenGroupedInSubFolder = false, bool noReverseGeocodeGroupedInSubFolder = false)
 	{
 		var fileSystem = new MockFileSystem();
 		var sut = new DirectoryGrouperService(fileSystem, ToolOptionFakes.Create(), NullLogger<DirectoryGrouperService>.Instance, ConsoleWriterFakes.Valid());
-		var groupedPhotoPathsByRelativeDirectory = sut.GroupFiles(photoExifDataByFilePath, SourcePath, folderProcessType, groupByFolderType,
-			noPhotoDateTimeTakenGroupedInSubFolder, noReverseGeocodeGroupedInSubFolder);
-		groupedPhotoPathsByRelativeDirectory.Should().BeEquivalentTo(expectedGroupedPhotoInfosByRelativeDirectory);
+
+		var actualGroupedPhotoPathsByRelativeDirectory = sut.GroupFiles(photoExifDataByFilePath, SourcePath, folderProcessType, groupByFolderType,
+			invalidFileFormatGroupedInSubFolder, noPhotoDateTimeTakenGroupedInSubFolder, noReverseGeocodeGroupedInSubFolder);
+
+		actualGroupedPhotoPathsByRelativeDirectory.Should().BeEquivalentTo(expectedGroupedPhotoInfosByRelativeDirectory);
 	}
 
 	#endregion
 
 	#region Fakes
 
-	private static Photo SourceRootPhotoInfo(string fileName, ExifData exifData, string targetRelativeDirectoryPath)
+	private static Photo SourceRootPhotoInfo(string fileName, ExifData? exifData, string targetRelativeDirectoryPath)
 	{
-		return PhotoFakes.WithValidFilePath(SourcePath, fileName, exifData, targetRelativeDirectoryPath);
+		return PhotoFakes.WithValidFilePathAndExifData(SourcePath, fileName, exifData, targetRelativeDirectoryPath);
 	}
 
-	private static Photo SourceSubPhotoInfo(string fileName, ExifData exifData, string targetRelativeDirectoryPath)
+	private static Photo SourceSubPhotoInfo(string fileName, ExifData? exifData, string targetRelativeDirectoryPath)
 	{
-		return PhotoFakes.WithValidFilePath($"{SourcePath}/{SubPath}", fileName, exifData, targetRelativeDirectoryPath);
+		return PhotoFakes.WithValidFilePathAndExifData($"{SourcePath}/{SubPath}", fileName, exifData, targetRelativeDirectoryPath);
+	}
+
+	private static Photo SourceRootPhotoInfoInvalidFileFormat(string fileName, string targetRelativeDirectoryPath)
+	{
+		return PhotoFakes.WithValidFilePathInvalidFileFormat(SourcePath, fileName, targetRelativeDirectoryPath);
+	}
+
+	private static Photo SourceSubPhotoInfoInvalidFileFormat(string fileName, string targetRelativeDirectoryPath)
+	{
+		return PhotoFakes.WithValidFilePathInvalidFileFormat($"{SourcePath}/{SubPath}", fileName, targetRelativeDirectoryPath);
 	}
 
 	private static string SourceRootPath(string fileName)
@@ -684,6 +1099,7 @@ public class DirectoryGrouperServiceUnitTests
 
 	private const string SourcePath = "source-path";
 	private const string SubPath = "sub-path";
+	private const string RootTargetRelativePath = "";
 
 	#endregion
 }

--- a/tests/UnitTests/Services/ExifDataAppenderServiceUnitTests.cs
+++ b/tests/UnitTests/Services/ExifDataAppenderServiceUnitTests.cs
@@ -5,7 +5,7 @@ namespace PhotoCli.Tests.UnitTests.Services;
 public class ExifDataAppenderServiceUnitTests
 {
 	private readonly Mock<IExifParserService> _parsePhotoTakenDateTime;
-	private readonly ISetup<IExifParserService, ExifData> _setupParseExifData;
+	private readonly ISetup<IExifParserService, ExifData?> _setupParseExifData;
 
 	public ExifDataAppenderServiceUnitTests()
 	{
@@ -26,9 +26,9 @@ public class ExifDataAppenderServiceUnitTests
 		}
 	};
 
-	public static TheoryData<Dictionary<string, ExifData>> NoPhotoTakenDateData = new()
+	public static TheoryData<Dictionary<string, ExifData?>> NoPhotoTakenDateData = new()
 	{
-		new Dictionary<string, ExifData>
+		new Dictionary<string, ExifData?>
 		{
 			{ "path", ExifDataFakes.WithNoPhotoTakenDate() }
 		}
@@ -38,11 +38,11 @@ public class ExifDataAppenderServiceUnitTests
 	[Theory]
 	[MemberData(nameof(ValidData))]
 	[MemberData(nameof(NoPhotoTakenDateData))]
-	public void PhotoTakenByPath_Returns_Dictionary_Key_As_Path_And_Value_As_PhotoTaken(Dictionary<string, ExifData> photoExifDataDictionarySample)
+	public void PhotoTakenByPath_Returns_Dictionary_Key_As_Path_And_Value_As_PhotoTaken(Dictionary<string, ExifData?> photoExifDataDictionarySample)
 	{
-		_setupParseExifData.Returns((string path, bool _, bool _) => photoExifDataDictionarySample[path]);
+		_setupParseExifData.Returns((string path, bool _, bool _) => photoExifDataDictionarySample[path]!);
 		var sut = new ExifDataAppenderService(_parsePhotoTakenDateTime.Object, StatisticsFakes.Empty(), ConsoleWriterFakes.Valid());
-		var photoTakenDictionary = sut.ExifDataByPath(photoExifDataDictionarySample.Keys.ToArray(), out _, out _);
+		var photoTakenDictionary = sut.ExifDataByPath(photoExifDataDictionarySample.Keys.ToArray(), out _, out _, out _);
 		photoTakenDictionary.Should().BeEquivalentTo(photoExifDataDictionarySample);
 	}
 }

--- a/tests/UnitTests/Services/ExifOrganizerServiceUnitTests.cs
+++ b/tests/UnitTests/Services/ExifOrganizerServiceUnitTests.cs
@@ -1,12 +1,12 @@
 namespace PhotoCli.Tests.UnitTests.Services;
 
-public class PhotoOrganizerUnitTests
+public class ExifOrganizerUnitTests
 {
 	#region NoPhotoDateTimeTakenAction
 
 	#region All Valid Photo
 
-	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> AllPhotosThatHasDateEnsureListOrderedData = new()
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> PhotoDateTimeTakenActionAllPhotosThatHasDateEnsureListOrderedData = new()
 	{
 		{
 			new List<Photo> { PhotoFakes.WithDay(1) },
@@ -31,8 +31,8 @@ public class PhotoOrganizerUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(AllPhotosThatHasDateEnsureListOrderedData))]
-	public void All_Photos_That_Has_Date_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	[MemberData(nameof(PhotoDateTimeTakenActionAllPhotosThatHasDateEnsureListOrderedData))]
+	public void PhotoDateTimeTakenAction_All_Photos_That_Has_Date_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
 	{
 		var noPhotoDateTimeTakenActions = new[]
 		{
@@ -40,14 +40,14 @@ public class PhotoOrganizerUnitTests
 			CopyNoPhotoTakenDateAction.Continue, CopyNoPhotoTakenDateAction.InsertToBeginningOrderByFileName
 		};
 		foreach (var noPhotoDateTimeTakenAction in noPhotoDateTimeTakenActions)
-			OrderCheckListEquivalent(sourceList, expectedOrderedList, noPhotoDateTimeTakenAction);
+			OrderCheckListEquivalent(sourceList, expectedOrderedList, noPhotoDateTimeTakenAction: noPhotoDateTimeTakenAction);
 	}
 
 	#endregion
 
 	#region DontCopyToOutput
 
-	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> CombinedPhotosWithDateAndNoDateShouldBeFilteredAndEnsureListOrderedData = new()
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> PhotoDateTimeTakenActionCombinedPhotosWithDateAndNoDateShouldBeFilteredAndEnsureListOrderedData = new()
 	{
 		{
 			new List<Photo> { PhotoFakes.NoPhotoTakenDate() },
@@ -68,17 +68,17 @@ public class PhotoOrganizerUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(CombinedPhotosWithDateAndNoDateShouldBeFilteredAndEnsureListOrderedData))]
-	public void With_DontCopyToOutput_Combined_Photos_With_Date_And_No_Date_Should_Be_Filtered_And_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	[MemberData(nameof(PhotoDateTimeTakenActionCombinedPhotosWithDateAndNoDateShouldBeFilteredAndEnsureListOrderedData))]
+	public void PhotoDateTimeTakenAction_With_DontCopyToOutput_Combined_Photos_With_Date_And_No_Date_Should_Be_Filtered_And_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
 	{
-		OrderCheckListEquivalent(sourceList, expectedOrderedList, CopyNoPhotoTakenDateAction.DontCopyToOutput);
+		OrderCheckListEquivalent(sourceList, expectedOrderedList, noPhotoDateTimeTakenAction: CopyNoPhotoTakenDateAction.DontCopyToOutput);
 	}
 
 	#endregion
 
 	#region AppendToEndOrderByFileName
 
-	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> AppendToEndOrderByFileNameEnsureListOrderedData = new()
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> PhotoDateTimeTakenActionAppendToEndOrderByFileNameEnsureListOrderedData = new()
 	{
 		{
 			new List<Photo> { PhotoFakes.NoPhotoTakenDate() },
@@ -103,17 +103,17 @@ public class PhotoOrganizerUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(AppendToEndOrderByFileNameEnsureListOrderedData))]
-	public void AppendToEndOrderByFileName_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	[MemberData(nameof(PhotoDateTimeTakenActionAppendToEndOrderByFileNameEnsureListOrderedData))]
+	public void PhotoDateTimeTakenAction_AppendToEndOrderByFileName_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
 	{
-		OrderCheckListEquivalent(sourceList, expectedOrderedList, CopyNoPhotoTakenDateAction.AppendToEndOrderByFileName);
+		OrderCheckListEquivalent(sourceList, expectedOrderedList, noPhotoDateTimeTakenAction: CopyNoPhotoTakenDateAction.AppendToEndOrderByFileName);
 	}
 
 	#endregion
 
 	#region InsertToBeginningOrderByFileName
 
-	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> InsertToBeginningOrderByFileNameEnsureListOrderedData = new()
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> PhotoDateTimeTakenActionInsertToBeginningOrderByFileNameEnsureListOrderedData = new()
 	{
 		{
 			new List<Photo> { PhotoFakes.NoPhotoTakenDate() },
@@ -138,10 +138,10 @@ public class PhotoOrganizerUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(InsertToBeginningOrderByFileNameEnsureListOrderedData))]
-	public void InsertToBeginningOrderByFileName_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	[MemberData(nameof(PhotoDateTimeTakenActionInsertToBeginningOrderByFileNameEnsureListOrderedData))]
+	public void PhotoDateTimeTakenAction_InsertToBeginningOrderByFileName_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
 	{
-		OrderCheckListEquivalent(sourceList, expectedOrderedList, CopyNoPhotoTakenDateAction.InsertToBeginningOrderByFileName);
+		OrderCheckListEquivalent(sourceList, expectedOrderedList, noPhotoDateTimeTakenAction: CopyNoPhotoTakenDateAction.InsertToBeginningOrderByFileName);
 	}
 
 	#endregion
@@ -152,7 +152,7 @@ public class PhotoOrganizerUnitTests
 
 	#region All Valid ReverseGeocode
 
-	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> AllPhotosThatHasReverseGeocodeEnsureListOrderedData = new()
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> NoCoordinateActionAllPhotosThatHasReverseGeocodeEnsureListOrderedData = new()
 	{
 		{
 			new List<Photo> { PhotoFakes.WithReverseGeocodeAndDay(1, 1) },
@@ -169,8 +169,8 @@ public class PhotoOrganizerUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(AllPhotosThatHasReverseGeocodeEnsureListOrderedData))]
-	public void All_Photos_That_Has_ReverseGeocode_Ensure_List_Not_Filtered_And_Ordered_By_Date(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	[MemberData(nameof(NoCoordinateActionAllPhotosThatHasReverseGeocodeEnsureListOrderedData))]
+	public void NoCoordinateAction_All_Photos_That_Has_ReverseGeocode_Ensure_List_Not_Filtered_And_Ordered_By_Date(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
 	{
 		var noCoordinateActions = new[]
 		{
@@ -184,7 +184,7 @@ public class PhotoOrganizerUnitTests
 
 	#region DontCopyToOutput
 
-	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> CombinedPhotosThatHasReverseGeocodeOrNoReverseGeocodeEnsureListFilteredData = new()
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> NoCoordinateActionCombinedPhotosThatHasReverseGeocodeOrNoReverseGeocodeEnsureListFilteredData = new()
 	{
 		{
 			new List<Photo> { PhotoFakes.NoReverseGeocode() },
@@ -201,8 +201,8 @@ public class PhotoOrganizerUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(CombinedPhotosThatHasReverseGeocodeOrNoReverseGeocodeEnsureListFilteredData))]
-	public void Combined_Photos_That_Has_ReverseGeocode_Or_NoReverseGeocode_Ensure_List_Filtered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	[MemberData(nameof(NoCoordinateActionCombinedPhotosThatHasReverseGeocodeOrNoReverseGeocodeEnsureListFilteredData))]
+	public void NoCoordinateAction_Combined_Photos_That_Has_ReverseGeocode_Or_NoReverseGeocode_Ensure_List_Filtered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
 	{
 		OrderCheckListEquivalent(sourceList, expectedOrderedList, noCoordinateAction: CopyNoCoordinateAction.DontCopyToOutput);
 	}
@@ -215,7 +215,7 @@ public class PhotoOrganizerUnitTests
 
 	#region Both DontCopyToOutput
 
-	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> UsingDontCopyToOutputOnPhotoTakenDateActionAndNoCoordinateActionEnsureListFilteredAndOrderedData = new()
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> NoPhotoDateTimeAndNoCoordinateActionUsingDontCopyToOutputOnPhotoTakenDateActionAndNoCoordinateActionEnsureListFilteredAndOrderedData = new()
 	{
 		{
 			new List<Photo> { PhotoFakes.NoPhotoTakenDate(), PhotoFakes.NoReverseGeocode() },
@@ -232,10 +232,10 @@ public class PhotoOrganizerUnitTests
 	};
 
 	[Theory]
-	[MemberData(nameof(UsingDontCopyToOutputOnPhotoTakenDateActionAndNoCoordinateActionEnsureListFilteredAndOrderedData))]
-	public void Using_DontCopyToOutput_On_PhotoTakenDateAction_And_NoCoordinateAction_Ensure_List_Filtered_And_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	[MemberData(nameof(NoPhotoDateTimeAndNoCoordinateActionUsingDontCopyToOutputOnPhotoTakenDateActionAndNoCoordinateActionEnsureListFilteredAndOrderedData))]
+	public void NoPhotoDateTimeAndNoCoordinateAction_Using_DontCopyToOutput_On_PhotoTakenDateAction_And_NoCoordinateAction_Ensure_List_Filtered_And_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
 	{
-		OrderCheckListEquivalent(sourceList, expectedOrderedList, CopyNoPhotoTakenDateAction.DontCopyToOutput, CopyNoCoordinateAction.DontCopyToOutput);
+		OrderCheckListEquivalent(sourceList, expectedOrderedList, noPhotoDateTimeTakenAction: CopyNoPhotoTakenDateAction.DontCopyToOutput, noCoordinateAction: CopyNoCoordinateAction.DontCopyToOutput);
 	}
 
 	#endregion
@@ -267,8 +267,92 @@ public class PhotoOrganizerUnitTests
 	public void Using_CopyToOutputDontChangeFileName_On_PhotoTakenDateAction_And_NoCoordinateAction_Ensure_List_Filtered_And_Ordered(List<Photo> sourceList,
 		IReadOnlyCollection<Photo> expectedOrderedList, IReadOnlyCollection<Photo> expectedNotToRenamePhotos)
 	{
-		OrderCheckListEquivalentWithNotToRenamePhotos(sourceList, expectedOrderedList, expectedNotToRenamePhotos, CopyNoPhotoTakenDateAction.Continue,
-			CopyNoCoordinateAction.Continue);
+		OrderCheckListEquivalentWithNotToRenamePhotos(sourceList, expectedOrderedList, expectedNotToRenamePhotos, noPhotoDateTimeTakenAction: CopyNoPhotoTakenDateAction.Continue,
+			noCoordinateAction: CopyNoCoordinateAction.Continue);
+	}
+
+	#endregion
+
+	#endregion
+
+	#region InvalidFormatAction
+
+	#region All Valid Photo
+
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> InvalidFormatActionAllPhotosThatIsValidEnsureListOrderedByPhotoTakeDateData = new()
+	{
+		{
+			new List<Photo> { PhotoFakes.ValidFileWithDay(1) },
+			new List<Photo> { PhotoFakes.ValidFileWithDay(1) }
+		},
+		{
+			new List<Photo> { PhotoFakes.ValidFileWithDay(1), PhotoFakes.ValidFileWithDay(2) },
+			new List<Photo> { PhotoFakes.ValidFileWithDay(1), PhotoFakes.ValidFileWithDay(2) }
+		},
+		{
+			new List<Photo> { PhotoFakes.ValidFileWithDay(2), PhotoFakes.ValidFileWithDay(1) },
+			new List<Photo> { PhotoFakes.ValidFileWithDay(1), PhotoFakes.ValidFileWithDay(2) }
+		},
+		{
+			new List<Photo> { PhotoFakes.ValidFileWithDay(2), PhotoFakes.ValidFileWithDay(1) },
+			new List<Photo> { PhotoFakes.ValidFileWithDay(1), PhotoFakes.ValidFileWithDay(2) }
+		},
+		{
+			new List<Photo> { PhotoFakes.ValidFileWithDay(2), PhotoFakes.ValidFileWithDay(3), PhotoFakes.ValidFileWithDay(1) },
+			new List<Photo> { PhotoFakes.ValidFileWithDay(1), PhotoFakes.ValidFileWithDay(2), PhotoFakes.ValidFileWithDay(3) }
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(InvalidFormatActionAllPhotosThatIsValidEnsureListOrderedByPhotoTakeDateData))]
+	public void InvalidFormatAction_All_Photos_That_Is_Valid_Ensure_List_Ordered_By_Photo_Take_Date(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	{
+		var invalidFormatActions = new[]
+		{
+			CopyInvalidFormatAction.Continue, CopyInvalidFormatAction.PreventProcess, CopyInvalidFormatAction.InSubFolder, CopyInvalidFormatAction.DontCopyToOutput
+		};
+		foreach (var invalidFormatAction in invalidFormatActions)
+			OrderCheckListEquivalent(sourceList, expectedOrderedList, invalidFormatAction: invalidFormatAction);
+	}
+
+	#endregion
+
+	#region DontCopyToOutput
+
+	public static TheoryData<List<Photo>, IReadOnlyCollection<Photo>> InvalidFormatActionDontCopyToOutputCombinedPhotosWithValidAndInvalidShouldBeFilteredAndEnsureListOrderedData = new()
+	{
+
+		{
+			new List<Photo> { PhotoFakes.WithInvalidFileFormat() },
+			new List<Photo>()
+		},
+		{
+			new List<Photo> { PhotoFakes.WithInvalidFileFormat(), PhotoFakes.WithDay(2) },
+			new List<Photo> { PhotoFakes.WithDay(2) }
+		},
+		{
+			new List<Photo> { PhotoFakes.WithInvalidFileFormat(), PhotoFakes.WithDay(1) },
+			new List<Photo> { PhotoFakes.WithDay(1) }
+		},
+		{
+			new List<Photo> { PhotoFakes.WithDay(3), PhotoFakes.WithDay(2), PhotoFakes.WithInvalidFileFormat() },
+			new List<Photo> { PhotoFakes.WithDay(2), PhotoFakes.WithDay(3) }
+		},
+		{
+			new List<Photo> { PhotoFakes.WithInvalidFileFormat(), PhotoFakes.NoPhotoTakenDate() },
+			new List<Photo> { PhotoFakes.NoPhotoTakenDate() }
+		},
+		{
+			new List<Photo> { PhotoFakes.NoReverseGeocode(), PhotoFakes.WithInvalidFileFormat()},
+			new List<Photo> { PhotoFakes.NoReverseGeocode() }
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(InvalidFormatActionDontCopyToOutputCombinedPhotosWithValidAndInvalidShouldBeFilteredAndEnsureListOrderedData))]
+	public void InvalidFormatAction_DontCopyToOutput_Combined_Photos_With_Valid_And_Invalid_Should_Be_Filtered_And_Ensure_List_Ordered(List<Photo> sourceList, IReadOnlyCollection<Photo> expectedOrderedList)
+	{
+		OrderCheckListEquivalent(sourceList, expectedOrderedList, invalidFormatAction: CopyInvalidFormatAction.DontCopyToOutput);
 	}
 
 	#endregion
@@ -276,18 +360,18 @@ public class PhotoOrganizerUnitTests
 	#endregion
 
 	private void OrderCheckListEquivalent(IReadOnlyCollection<Photo> sourceList, IEnumerable<Photo> expectedOrderedList,
-		CopyNoPhotoTakenDateAction noPhotoDateTimeTakenAction = CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction noCoordinateAction = CopyNoCoordinateAction.Continue)
+		CopyInvalidFormatAction invalidFormatAction = CopyInvalidFormatAction.Continue, CopyNoPhotoTakenDateAction noPhotoDateTimeTakenAction = CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction noCoordinateAction = CopyNoCoordinateAction.Continue)
 	{
 		var sut = new ExifOrganizerService(NullLogger<ExifOrganizerService>.Instance);
-		var (orderedPhotos, _) = sut.FilterAndSortByNoActionTypes(sourceList, noPhotoDateTimeTakenAction, noCoordinateAction);
+		var (orderedPhotos, _) = sut.FilterAndSortByNoActionTypes(sourceList, invalidFormatAction, noPhotoDateTimeTakenAction, noCoordinateAction, string.Empty);
 		orderedPhotos.Should().BeEquivalentTo(expectedOrderedList, options => options.WithStrictOrdering());
 	}
 
 	private void OrderCheckListEquivalentWithNotToRenamePhotos(IReadOnlyCollection<Photo> sourceList, IEnumerable<Photo> expectedOrderedList, IEnumerable<Photo> expectedNotToRenamePhotos,
-		CopyNoPhotoTakenDateAction noPhotoDateTimeTakenAction, CopyNoCoordinateAction noCoordinateAction)
+		CopyInvalidFormatAction invalidFormatAction = CopyInvalidFormatAction.Continue, CopyNoPhotoTakenDateAction noPhotoDateTimeTakenAction = CopyNoPhotoTakenDateAction.Continue, CopyNoCoordinateAction noCoordinateAction = CopyNoCoordinateAction.Continue)
 	{
 		var sut = new ExifOrganizerService(NullLogger<ExifOrganizerService>.Instance);
-		var (orderedPhotos, notToRenamePhotos) = sut.FilterAndSortByNoActionTypes(sourceList, noPhotoDateTimeTakenAction, noCoordinateAction);
+		var (orderedPhotos, notToRenamePhotos) = sut.FilterAndSortByNoActionTypes(sourceList, invalidFormatAction, noPhotoDateTimeTakenAction, noCoordinateAction, string.Empty);
 		orderedPhotos.Should().BeEquivalentTo(expectedOrderedList, options => options.WithStrictOrdering());
 		notToRenamePhotos.Should().BeEquivalentTo(expectedNotToRenamePhotos, options => options.WithStrictOrdering());
 	}

--- a/tests/UnitTests/Services/ReverseGeocodeFetcherServiceUnitTests.cs
+++ b/tests/UnitTests/Services/ReverseGeocodeFetcherServiceUnitTests.cs
@@ -71,7 +71,7 @@ public class ReverseGeocodeFetcherServiceUnitTests
 	[MemberData(nameof(FetchQueueIsSameWithConnectionLimit))]
 	[MemberData(nameof(FetchQueueIsBiggerThanConnectionLimit))]
 	public async Task Check_Concurrent_ReverseGeocode_Requests_Obeys_ConnectionLimit_By_Checking_Possible_Elapsed_Duration_Is_Between_Minimum_And_Maximum(ReverseGeocodeProvider reverseGeocodeProvider,
-		int connectionLimit, TimeSpan fetchDuration, Dictionary<string, ExifData> sourceExifDataByFilePath)
+		int connectionLimit, TimeSpan fetchDuration, Dictionary<string, ExifData?> sourceExifDataByFilePath)
 	{
 		var semaphoreMinimumCircuitCount = Math.Ceiling((float)sourceExifDataByFilePath.Count / connectionLimit);
 		var minimumFetchTime = fetchDuration * semaphoreMinimumCircuitCount;
@@ -121,7 +121,7 @@ public class ReverseGeocodeFetcherServiceUnitTests
 	[Theory]
 	[MemberData(nameof(ObeyReverseGeocodeProvidersRateLimitData))]
 	public async Task Check_Obeying_ReverseGeocode_Providers_Rate_Limit_By_Checking_Possible_Elapsed_Duration_Is_Between_Minimum_And_Maximum(ReverseGeocodeProvider reverseGeocodeProvider,
-		TimeSpan reverseGeocodeServiceRateLimitBetweenEachRequest, Dictionary<string, ExifData> sourceExifDataByFilePath)
+		TimeSpan reverseGeocodeServiceRateLimitBetweenEachRequest, Dictionary<string, ExifData?> sourceExifDataByFilePath)
 	{
 		var minimumFetchTime = reverseGeocodeServiceRateLimitBetweenEachRequest * sourceExifDataByFilePath.Count;
 		var reverseGeocodeMock = new Mock<IReverseGeocodeService>(MockBehavior.Strict);
@@ -253,8 +253,8 @@ public class ReverseGeocodeFetcherServiceUnitTests
 	[Theory]
 	[MemberData(nameof(CoordinatesExifDataWithExpectedReverseGeocode))]
 	[MemberData(nameof(NoCoordinateShouldReturnWithNoReverseGeocodeSet))]
-	public async Task Given_Source_Dictionary_Should_Return_With_ReverseGeocode_Property_Set_On_Each_ExifData_Value(Dictionary<string, ExifData> sourceExifDataByFilePath,
-		Dictionary<string, ExifData> expectedResultExifDataByFilePath)
+	public async Task Given_Source_Dictionary_Should_Return_With_ReverseGeocode_Property_Set_On_Each_ExifData_Value(Dictionary<string, ExifData?> sourceExifDataByFilePath,
+		Dictionary<string, ExifData?> expectedResultExifDataByFilePath)
 	{
 		var reverseGeocodeMock = new Mock<IReverseGeocodeService>(MockBehavior.Strict);
 		reverseGeocodeMock.Setup(s => s.Get(It.IsAny<Coordinate>()))


### PR DESCRIPTION

On `copy` verb, I have added `--invalid-format` or `-x` with the values of

```
public enum CopyInvalidFormatAction : byte
{
	Continue = 0,
	PreventProcess = 1,
	DontCopyToOutput = 2,
	InSubFolder = 3,
}
```

- Default is `Continue = 0` . It will copy your invalid/unreadable formatted photo to output without no naming. 

- `PreventProcess = 1` breaks processing. 
- `DontCopyToOutput = 2` will filter and copy/process only readable formats. Will give you the list files that is not readable.
- `InSubFolder = 3` will put invalid/unreadable photos in a separate folder.

fix #14