### PR TITLE
Model Context Protocol Support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,6 +61,11 @@ photo-cli help [command]
 dotnet tool uninstall -g photo-cli
 ```
 
+## MCP Server Setup
+
+The `mcp` command is built into `photo-cli` and requires no additional installation. It starts an [MCP](https://modelcontextprotocol.io/) stdio server on top of an existing archive folder (one previously created with `photo-cli archive`).
+
+See the [MCP section in README](README.md#mcp-model-context-protocol-server) for setup instructions for Claude Code, Claude Desktop, VS Code, and MCP Inspector.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 - [Features Explained With An Example](#features-explained-with-examples)
 - [Installation](#installation)
+- [MCP (Model Context Protocol) Server](#mcp-model-context-protocol-server)
 - [Sample Usage Screenshots](#sample-usage-screenshots)
 - [How It's Done?](#how-its-done)
 - [Supported Photo Types](#supported-photo-types)
@@ -729,6 +730,101 @@ This application can be installed by Homebrew (macOS & Linux), container (Docker
 See the [installation](INSTALL.md) for details.
 
 Note: You may test commands on [test photographs](docs/test-photographs) which has coordinates and photograph taken dates in it.
+
+## MCP (Model Context Protocol) Server
+
+`photo-cli` can act as an [MCP](https://modelcontextprotocol.io/) stdio server, exposing your archived photo database to AI assistants (Claude, Visual Studio Code, etc.) so they can query your photos conversationally.
+
+### Prerequisites
+
+- A photo archive folder created with `photo-cli archive` (must contain the `photo-cli.db` SQLite database).
+- .NET runtime available (or use the self-contained executable).
+
+### MCP Tools Exposed
+
+| Tool                        | Description                                                                                     |
+|-----------------------------|-----------------------------------------------------------------------------------------------------|
+| `search_photos`             | Search photos by date range, location text, or limit. Returns paths, dates, and location info.      |
+| `get_photo`                 | Get full metadata for a specific photo by its archive file path.                                    |
+| `list_albums`               | List all albums with id, name, type, creation date, and configuration.                              |
+| `get_statistics`            | Get photo counts grouped by year, month, country, city, or camera model.                            |
+| `find_near_location`        | Find photos taken near a GPS coordinate within a given radius (Haversine formula).                  |
+| `list_photos_by_album_id`   | List photos belonging to an album by its numeric ID. Returns paths, dates, and location info.       |
+| `list_photos_by_album_name` | List photos belonging to an album by its name. Returns paths, dates, and location info.             |
+| `list_photos_by_exact_date` | List photos matching an exact date (year, month, day). All parameters are optional.                 |
+| `list_photos_by_date_range` | List photos within a date range. Both start and end dates are inclusive.                             |
+| `open_photos_by_album_id`   | Open photos belonging to an album by its numeric ID in the default viewer (macOS Preview).          |
+| `open_photos_by_album_name` | Open photos belonging to an album by its name in the default viewer (macOS Preview).                |
+| `open_photos_by_exact_date` | Open photos matching an exact date in the default viewer (macOS Preview). All parameters optional.  |
+| `open_photos_by_date_range` | Open photos within a date range in the default viewer (macOS Preview). Dates are inclusive.          |
+
+### Setup
+
+#### Claude Code (CLI)
+
+```shell
+claude mcp add photo-cli --scope user -- photo-cli mcp --input /path/to/archive-folder
+```
+
+#### Claude Code Config (`~/.claude.json`)
+
+```json
+"mcpServers": {
+  "photo-cli": {
+    "command": "photo-cli",
+    "args": [
+      "mcp",
+      "--input",
+      "/path/to/archive-folder"
+    ]
+  }
+}
+```
+
+#### Claude Desktop (`claude_desktop_config.json`)
+
+```json
+"mcpServers": {
+  "photo-cli": {
+    "command": "photo-cli",
+    "args": [
+      "mcp",
+      "--input",
+      "/path/to/archive-folder"
+    ]
+  }
+}
+```
+
+#### VS Code (`.vscode/mcp.json` or user settings)
+
+```json
+"photo-cli": {
+  "type": "stdio",
+  "command": "photo-cli",
+  "args": [
+    "mcp",
+    "--input",
+    "/path/to/archive-folder"
+  ]
+}
+```
+
+#### MCP Inspector (for debugging/testing)
+
+```shell
+npx @modelcontextprotocol/inspector photo-cli mcp --input /path/to/archive-folder
+```
+
+### `mcp` Command Arguments
+
+```
+photo-cli help mcp
+```
+
+| Argument           | Short | Description                                                                                             |
+|--------------------|-------|---------------------------------------------------------------------------------------------------------|
+| `--input`          | `-i`  | Archive folder path containing the photo-cli database to expose via MCP. Defaults to current directory. |
 
 ## Sample Usage Screenshots
 
@@ -1597,6 +1693,7 @@ photo-cli copy --process-type FlattenAllSubFolders --group-by AddressHierarchy -
 | [`info`](#info)         | Creates a report (CSV file) listing all photo taken date and address (reverse geocode).                                                                                                                            |
 | [`address`](#address)   | Get address (reverse geocode) of single photo.                                                                                                                                                                     |
 | [`settings`](#settings) | Lists, saves and get settings.                                                                                                                                                                                     |
+| [`mcp`](#mcp-model-context-protocol-server) | Start an MCP (Model Context Protocol) stdio server to query the photo archive database.                                                                    |
 
 ### Archive
 

--- a/README.md
+++ b/README.md
@@ -2202,38 +2202,130 @@ photo-cli help list
   <summary>Click to expand</summary>
 
 ```
-  -t, --type     (Optional) Listing type for archive folder
+  -t, --type          (Optional) Listing type for archive folder
 
-                 Summary: 0 [default] - Shows total counts of albums, photos,
-                 and reverse geocode cache entries
+                      Summary: 0 [default] - Shows total counts of albums,
+                      photos, and reverse geocode cache entries
 
-                 Albums: 1 - Lists all albums with their id, name, type,
-                 creation date, and configuration
+                      Albums: 1 - Lists all albums with their id, name, type,
+                      creation date, and configuration
 
-                 PhotosByAlbum: 2 - Lists or opens photos belonging to a
-                 specific album (requires `--album-id`)
+                      PhotosByAlbumId: 2 - Lists or opens photos belonging to a
+                      specific album by the ID (requires `--id`)
 
-                 PhotosByDate: 3 - Lists or opens photos filtered by date
-                 (optionally filtered by `--year`, `--month`, `--day`)
+                      PhotosByAlbumName: 3 - Lists or opens photos belonging to
+                      a specific album by album name (requires `--name`)
 
-  -i, --input    Archive path to list & open photos from.
-                 Default current executing folder)
+                      PhotosByExactDate: 4 - Lists or opens photos filtered by
+                      date (optionally filtered by `--year`, `--month`, `--day`)
 
-  -n, --id       (Optional) Album ID to be used while using the list type of
-                 `PhotosByAlbum`
+                      PhotosByDateRange: 5 - Lists or opens photos within a date
+                      range (requires `--start-date` and `--end-date`)
 
-  -y, --year     (Optional) Year as number to be used while using the list type
-                 of `PhotosByDate`
+  -i, --input         Archive path to list & open photos from.
+                      Default current executing folder)
 
-  -m, --month    (Optional) Month as number to be used while using the list type
-                 of `PhotosByDate`
+  -n, --id            (Optional) Album ID to be used while using the list type
+                      of `PhotosByAlbumId`
 
-  -d, --day      (Optional) Day as number to be used while using the list type
-                 of `PhotosByDate`
+  -a, --name          (Optional) Album name to be used while using the list type
+                      of `PhotosByAlbumName`
 
-  -r, --raw      (Optional) Listing photo paths each on new line instead of
-                 trying to open the default OS app while using the list type of
-                 `PhotosByAlbum` or `PhotosByDate`.
+  -y, --year          (Optional) Year as number to be used while using the list
+                      type of `PhotosByExactDate`
+
+  -m, --month         (Optional) Month as number to be used while using the list
+                      type of `PhotosByExactDate`
+
+  -d, --day           (Optional) Day as number to be used while using the list
+                      type of `PhotosByExactDate`
+
+  -s, --start-date    (Optional) Start date (inclusive) to be used while using
+                      the list type of `PhotosByDateRange`
+
+  -e, --end-date      (Optional) End date (inclusive) to be used while using the
+                      list type of `PhotosByDateRange`
+
+  -r, --raw           (Optional) Listing photo paths each on new line instead of
+                      trying to open the default OS app while using the list
+                      type of `PhotosByAlbum` or `PhotosByExactDate`.
+
+  --help              Display this help screen.
+
+  --version           Display version information.
+
+NOTES:
+- Instead of option names (for ex: DateTimeWithMinutes), you may use options
+values too. (for ex: 3)
+- You can use relative folder paths. If you use the input folder as the working
+directory, you don't need to use the input argument.
+
+EXAMPLE USAGES:
+- List statistics of the archive folder
+
+Example with long argument names;
+photo-cli list --input (input-folder)
+
+Example with short argument names;
+photo-cli list -i (input-folder)
+
+- List all the album information of the archive folder
+
+Example with long argument names;
+photo-cli list --input (input-folder) --type Albums
+
+Example with short argument names;
+photo-cli list -i (input-folder) -t Albums
+
+- List paths (to be send as process arguments to photo viewers) or open (only
+supporting in macOS , Preview app for now) for the given album id
+
+Example with long argument names;
+photo-cli list --input (input-folder) --id 1 --type PhotosByAlbumId
+
+Example with short argument names;
+photo-cli list -i (input-folder) -n 1 -t PhotosByAlbumId
+
+- List paths (to be send as process arguments to photo viewers) or open (only
+supporting in macOS , Preview app for now) for the given year
+
+Example with long argument names;
+photo-cli list --input (input-folder) --type PhotosByExactDate --year 2007
+
+Example with short argument names;
+photo-cli list -i (input-folder) -t PhotosByExactDate -y 2007
+
+- List paths (to be send as process arguments to photo viewers) or open (only
+supporting in macOS , Preview app for now) for the given year & month
+
+Example with long argument names;
+photo-cli list --input (input-folder) --month 8 --type PhotosByExactDate --year
+2007
+
+Example with short argument names;
+photo-cli list -i (input-folder) -m 8 -t PhotosByExactDate -y 2007
+
+- List paths (to be send as process arguments to photo viewers) or open (only
+supporting in macOS , Preview app for now) for the given year, month & day
+
+Example with long argument names;
+photo-cli list --day 19 --input (input-folder) --month 8 --type
+PhotosByExactDate --year 2007
+
+Example with short argument names;
+photo-cli list -d 19 -i (input-folder) -m 8 -t PhotosByExactDate -y 2007
+
+- List paths (to be send as process arguments to photo viewers) or open (only
+supporting in macOS , Preview app for now) for photos taken within the given
+date range
+
+Example with long argument names;
+photo-cli list --type PhotosByDateRange --start-date 2025-09-21 --end-date
+2026-01-30 --input (input-folder)
+
+Example with short argument names;
+photo-cli list -t PhotosByDateRange -s 2025-09-21 -e 2026-01-30 -i
+(input-folder)
 ```
 </details>
 
@@ -2584,7 +2676,7 @@ photo-cli help settings
 
 ## Command Line Options / Arguments
 
-### Common Arguments Used Across Verbs (Command Type) in Same Purpose
+### Common Arguments Used Across Verbs (Command Type) in the Same Purpose
 
 #### Input Path ( -i, --input ) [optional]
 
@@ -2623,7 +2715,7 @@ Third-party provider to resolve photo taken address by photo's coordinates.
 | GoogleMaps              | 3     | Google's reverse geocoding API offering accurate global address resolution with support for multiple address component types. |
 | LocationIq              | 5     | A location data platform providing reverse geocoding based on OpenStreetMap data with both free and paid tiers.               |
 
-#### ( -z, --missing-reverse-geocode ) [optional]
+#### Missing Reverse Geocode  ( -z, --missing-reverse-geocode ) [optional]
 
 Used in: `archive`, `copy`, `info` verbs.
 
@@ -2634,11 +2726,11 @@ Action to take when any photo has missing reverse geocode information.
 | Continue (default) | 0 (default) | Ignores missing reverse geocode data and continues processing.  |
 | PreventProcess     | 1           | Stops the process if any photo is missing reverse geocode data. |
 
-#### ( -w, --expected-day-range ) [optional]
+#### Expected Day Range ( -w, --expected-day-range ) [optional]
 
 Used in: `archive`, `copy` verbs.
 
-Provide a maximum expected day difference as number for your photos to prevent processing if it's exceeding the range.
+Provide a maximum expected day difference as a number for your photos to prevent processing if it's exceeding the range.
 
 #### Big Data Cloud API Key ( -b, --bigdatacloud-key ) [optional]
 
@@ -2720,7 +2812,7 @@ Action to take when a photo has no coordinate.
 
 Strategy for reading photos from the input folder. You can read only a single folder (not reading any subfolders), keep your input folder hierarchy on the output, or flatten all subfolders into a single folder.
 
-You must select folder process behavior to whether use original folder hierarchy or flatten into single folder/grouped folder by [Group By Folder](#group-by-folder---g---group-by-).
+You must select folder process behavior to whether to use the original folder hierarchy or flatten into single folder/grouped folder by [Group By Folder](#group-by-folder---g---group-by-).
 
 | Option                            | Value | Description                                                                                                                                    |
 |-----------------------------------|-------|------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -2728,9 +2820,9 @@ You must select folder process behavior to whether use original folder hierarchy
 | SubFoldersPreserveFolderHierarchy | 2     | Creates input folder hierarchy on output.                                                                                                      |
 | FlattenAllSubFolders              | 3     | Flatten all subfolders into single folder.                                                                                                     |
 
-#### Naming Style ( -s, --naming-style )
+#### Naming Style ( -s, --naming-style ) [required]
 
-While copying to a new organized folder, you must select one of these file naming strategies for a newly copied photo file name.
+While copying to a new-organized folder, you must select one of these file naming strategies for a newly copied photo file name.
 
 | Option                     | Value | Description                                                                                                                                |
 |----------------------------|-------|--------------------------------------------------------------------------------------------------------------------------------------------|
@@ -2758,7 +2850,7 @@ Optional use for `copy` verb. While copying to a new organized folder (you shoul
 | DayRange               | 4     | Appends a date range spanning from the first to the last photo's date in the folder to the folder name.             |
 | MatchingMinimumAddress | 5     | Appends the common address prefix shared by all photos in the folder, based on matching reverse geocode properties. |
 
-#### Folder Append Location Type ( -p, --folder-append-location )
+#### Folder Append Location Type ( -p, --folder-append-location ) [optional]
 
 While copying to a new organized folder (you should select [Folder Process Type](#folder-process-type---f---process-type-) as `SubFoldersPreserveFolderHierarchy`), you may select one of these folder naming strategies. Must be used with [Folder Append Location](#folder-append-type---a---folder-append-)
 
@@ -2767,18 +2859,19 @@ While copying to a new organized folder (you should select [Folder Process Type]
 | Prefix | 1     | Prepends the appended name before the original folder name. |
 | Suffix | 2     | Appends the appended name after the original folder name.   |
 
-#### Group By Folder ( -g, --group-by )
+#### Group By Folder ( -g, --group-by ) [optional]
 
 Groups photos into directories in the file system by EXIF data.
 
-| Option       | Value | Description |
-|--------------|-------|-------------|
-| YearMonthDay | 1     |             |
-| YearMonth    | 2     |             |
-| Year         | 3     |             |
-| Address      | 4     |             |
+| Option           | Value | Description                                                                                                |
+|------------------|-------|------------------------------------------------------------------------------------------------------------|
+| YearMonthDay     | 1     | Groups photos into a `year/month/day` directory hierarchy based on the photo taken date.                   |
+| YearMonth        | 2     | Groups photos into a `year/month` directory hierarchy based on the photo taken date.                       |
+| Year             | 3     | Groups photos into a `year` directory based on the photo taken date.                                       |
+| AddressFlat      | 4     | Groups photos into a single flat directory named after the formatted reverse geocode address.              |
+| AddressHierarchy | 5     | Groups photos into a hierarchical directory structure with one folder level per reverse geocode component. |
 
-#### Number Naming Text Style ( -n, --number-style )
+#### Number Naming Text Style ( -n, --number-style ) [required]
 
 Number naming strategy must be selected when using [Naming Style](#naming-style---s---naming-style-) as `Numeric` or when numbering photos that would otherwise share the same name.
 
@@ -2788,11 +2881,11 @@ Number naming strategy must be selected when using [Naming Style](#naming-style-
 | PaddingZeroCharacter  | 2     | Generates sequential numbers starting from 1 with leading zeros padded to match the maximum digit length needed (e.g., 001, 002, 003 for a total count requiring three digits).                                  |
 | OnlySequentialNumbers | 3     | Generates plain sequential numbers starting from 1 without any padding or length constraints (e.g., 1, 2, 3, 10, 100).                                                                                           |
 
-#### Verify ( -v, --verify)
+#### Verify ( -v, --verify) [optional]
 
 Verify that all photo files copied successfully by comparing file hashes. (no extra parameter needed)
 
-#### No Photograph Taken Date Action [for `copy` command ] ( -t, --no-taken-date )
+#### No Photograph Taken Date Action [for `copy` command ] ( -t, --no-taken-date ) [optional]
 
 Optional action to take when a photograph has no taken date. Default is `Continue`.
 
@@ -2805,7 +2898,7 @@ Optional action to take when a photograph has no taken date. Default is `Continu
 | AppendToEndOrderByFileName       | 4           | Places photos without a taken date at the end of the sequence, ordered by filename, after all photos with taken dates.           |
 | InsertToBeginningOrderByFileName | 5           | Places photos without a taken date at the beginning of the sequence, ordered by filename, before all photos with taken dates.    |
 
-#### No Coordinate Action [for `copy` command ] ( -c, --no-coordinate )
+#### No Coordinate Action [for `copy` command ] ( -c, --no-coordinate ) [optional]
 
 Optional action to take when a photo has no coordinate.
 
@@ -2816,13 +2909,60 @@ Optional action to take when a photo has no coordinate.
 | DontCopyToOutput | 2     | Excludes photos without GPS coordinates from the output, only copying photos that have valid coordinate information.                |
 | InSubFolder      | 3     | Groups photos without GPS coordinates into a separate subfolder while copying photos with coordinates to their normal destinations. |
 
+### List Verb Arguments
+
+#### List Type ( -t, --type ) [required]
+
+Optional listing type that determines what data to display from the archive.
+
+| Option             | Value       | Description                                                                                                        |
+|--------------------|-------------|--------------------------------------------------------------------------------------------------------------------|
+| Summary            | 0 (default) | Shows total counts of albums, photos, and reverse geocode cache entries.                                           |
+| Albums             | 1           | Lists all albums with their id, name, type, creation date, and configuration.                                      |
+| PhotosByAlbumId    | 2           | Lists or opens photos belonging to a specific album by the ID (requires `--id`).                                   |
+| PhotosByAlbumName  | 3           | Lists or opens photos belonging to a specific album by album name (requires `--name`).                             |
+| PhotosByExactDate  | 4           | Lists or opens photos filtered by date (optionally filtered by `--year`, `--month`, `--day`).                      |
+| PhotosByDateRange  | 5           | Lists or opens photos within a date range (requires `--start-date` and `--end-date`).                              |
+
+#### Album Id ( -n, --id ) [optional]
+
+Album ID to filter photos when using list type `PhotosByAlbumId`.
+
+#### Album Name ( -a, --name ) [optional]
+
+Album name to filter photos when using list type `PhotosByAlbumName`.
+
+#### Year ( -y, --year ) [optional]
+
+Year as a number to filter photos when using list type `PhotosByExactDate`.
+
+#### Month ( -m, --month ) [optional]
+
+Month as a number to filter photos when using list type `PhotosByExactDate`.
+
+#### Day ( -d, --day ) [optional]
+
+Day as a number to filter photos when using list type `PhotosByExactDate`.
+
+#### Start Date ( -s, --start-date ) [optional]
+
+Start date (inclusive) to filter photos when using list type `PhotosByDateRange`.
+
+#### End Date ( -e, --end-date ) [optional]
+
+End date (inclusive) to filter photos when using list type `PhotosByDateRange`.
+
+#### Raw Output ( -r, --raw ) [optional]
+
+Lists photo paths each on a new line instead of trying to open the default OS app. Applicable when using list type `PhotosByAlbumId`, `PhotosByAlbumName`, or `PhotosByExactDate`. (no extra parameter needed)
+
 ### Info Verb Arguments
 
-#### All Folders ( -a, --all-folders )
+#### All Folders ( -a, --all-folders ) [optional]
 
 Optional behavior to read & list all photos in all subfolders. Default behavior is to read & list only photos in current working folder. (no extra parameter needed)
 
-#### No Photograph Taken Date Action [for `info` command ] ( -t, --no-taken-date )
+#### No Photograph Taken Date Action [for `info` command ] ( -t, --no-taken-date ) [optional]
 
 Optional action to take when a photograph has no taken date. Default is `Continue`.
 
@@ -2831,7 +2971,7 @@ Optional action to take when a photograph has no taken date. Default is `Continu
 | Continue (default)               | 0 (default) | Processes and creates output including those without a taken date without any special handling or filtering. |
 | PreventProcess                   | 1           | Stops the entire info operation if any photos without a taken date are found, returning an error exit code.  |
 
-#### No Coordinate Action [for `info` command ] ( -c, --no-coordinate )
+#### No Coordinate Action [for `info` command ] ( -c, --no-coordinate ) [optional]
 
 Optional action to take when a photo has no coordinate.
 
@@ -2968,6 +3108,7 @@ Process exit codes listed below;
 | ExistingAlbumConfigurationNotValid              | 57    | The existing album configuration in the database is corrupted or invalid.                       |
 | NoArchiveDatabaseFound                          | 60    | The archive database file was not found at the expected location.                               |
 | NoPhotoFoundToList                              | 61    | No photos matched the specified query filters.                                                  |
+| AlbumNotFoundByName                             | 62    | No album with the specified name was found in the database.                                     |
 
 ## Contributing
 

--- a/src/McpTools/ArchiveMcpTools.cs
+++ b/src/McpTools/ArchiveMcpTools.cs
@@ -1,0 +1,221 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace PhotoCli.McpTools;
+
+[McpServerToolType]
+public class ArchiveMcpTools(IDbService dbService, IProcessLauncher processLauncher, McpOptions mcpOptions)
+{
+	[McpServerTool(Name = "search_photos")]
+	[Description("Search photos in the archive by date range, location text, or limit results. Returns photo paths, dates, and location info.")]
+	public async Task<string> SearchPhotos(
+		[Description("Start date filter in ISO 8601 format (e.g. 2023-01-01). Optional.")] string? startDate = null,
+		[Description("End date filter in ISO 8601 format (e.g. 2023-12-31). Optional.")] string? endDate = null,
+		[Description("Text to search in the reverse geocode address (e.g. 'Paris', 'France'). Case-insensitive. Optional.")] string? location = null,
+		[Description("Maximum number of results to return. Default is 50.")] int limit = 50)
+	{
+		DateTime? start = !string.IsNullOrWhiteSpace(startDate) && DateTime.TryParse(startDate, out var s) ? s : null;
+		DateTime? end = !string.IsNullOrWhiteSpace(endDate) && DateTime.TryParse(endDate, out var e) ? e : null;
+
+		var photos = await dbService.SearchPhotos(start, end, location, limit);
+		var result = photos.Select(p => new { p.Path, p.DateTaken, p.ReverseGeocodeFormatted, p.Latitude, p.Longitude });
+		return JsonSerializer.Serialize(result, StaticOptions.McpToolOptions);
+	}
+
+	[McpServerTool(Name = "get_photo")]
+	[Description("Get full metadata for a specific photo by its file path.")]
+	public async Task<string> GetPhoto(
+		[Description("The relative file path of the photo as stored in the archive (e.g. '2023/06/15/abc123.jpg').")] string filePath)
+	{
+		var photo = await dbService.GetPhotoByPath(filePath);
+
+		if (photo == null)
+			return $"No photo found with path: {filePath}";
+
+		var result = new
+		{
+			photo.Id,
+			photo.Path,
+			photo.DateTaken,
+			photo.Year,
+			photo.Month,
+			photo.Day,
+			photo.Hour,
+			photo.Minute,
+			photo.Seconds,
+			photo.Latitude,
+			photo.Longitude,
+			photo.ReverseGeocodeFormatted,
+			photo.Address1,
+			photo.Address2,
+			photo.Address3,
+			photo.Address4,
+			photo.Address5,
+			photo.Address6,
+			photo.Address7,
+			photo.Address8,
+			photo.Sha1Hash,
+			photo.CreatedAt,
+		};
+		return JsonSerializer.Serialize(result, StaticOptions.McpToolOptions);
+	}
+
+	[McpServerTool(Name = "list_albums")]
+	[Description("List all albums in the archive with their id, name, type, creation date, and configuration.")]
+	public async Task<string> ListAlbums()
+	{
+		var albums = await dbService.GetAllAlbums();
+		var result = albums.Select(a => new { a.Id, a.Name, Type = a.Type.ToString(), a.CreatedAt, a.Configuration });
+		return JsonSerializer.Serialize(result, StaticOptions.McpToolOptions);
+	}
+
+	[McpServerTool(Name = "get_statistics")]
+	[Description("Get photo count statistics grouped by year, month, country (address1), city (address2), or camera model (address3).")]
+	public async Task<string> GetStatistics(
+		[Description("How to group the statistics. One of: year, month, location, address1, address2, address3, address4. Default is year.")] string groupBy = "year")
+	{
+		var rows = await dbService.GetPhotoStatistics(groupBy);
+		if (rows.Count == 0 && !IsKnownGroupBy(groupBy))
+			return $"Unknown groupBy value '{groupBy}'. Use: year, month, location, address1, address2, address3, address4";
+		return JsonSerializer.Serialize(rows, StaticOptions.McpToolOptions);
+	}
+
+	[McpServerTool(Name = "find_near_location")]
+	[Description("Find photos taken near a GPS coordinate within a given radius. Uses Haversine distance formula.")]
+	public async Task<string> FindNearLocation(
+		[Description("Latitude of the center point (decimal degrees, e.g. 48.8566).")] double latitude,
+		[Description("Longitude of the center point (decimal degrees, e.g. 2.3522).")] double longitude,
+		[Description("Search radius in kilometers. Default is 10.")] double radiusKm = 10,
+		[Description("Maximum number of results to return. Default is 20.")] int limit = 20)
+	{
+		var results = await dbService.FindPhotosNearLocation(latitude, longitude, radiusKm, limit);
+		return JsonSerializer.Serialize(results, StaticOptions.McpToolOptions);
+	}
+
+	[McpServerTool(Name = "list_photos_by_album_id")]
+	[Description("List photos belonging to an album by its numeric ID. Returns photo paths, dates, and location info.")]
+	public async Task<string> ListPhotosByAlbumId(
+		[Description("The numeric ID of the album.")] int albumId)
+	{
+		var albumPhotoResult = await dbService.GetAlbumPhotosById(albumId);
+		return albumPhotoResult.Status switch
+		{
+			AlbumPhotoResultStatus.Successful => SerializePhotos(albumPhotoResult.Photos),
+			AlbumPhotoResultStatus.AlbumNotFound => $"Album with id {albumId} not found.",
+			AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat => $"Album with id {albumId} has invalid configuration.",
+			_ => $"Unexpected error for album id {albumId}."
+		};
+	}
+
+	[McpServerTool(Name = "list_photos_by_album_name")]
+	[Description("List photos belonging to an album by its name. Returns photo paths, dates, and location info.")]
+	public async Task<string> ListPhotosByAlbumName(
+		[Description("The name of the album.")] string albumName)
+	{
+		var albumPhotoResult = await dbService.GetAlbumPhotosByName(albumName);
+		return albumPhotoResult.Status switch
+		{
+			AlbumPhotoResultStatus.Successful => SerializePhotos(albumPhotoResult.Photos),
+			AlbumPhotoResultStatus.AlbumNotFound => $"Album with name '{albumName}' not found.",
+			AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat => $"Album with name '{albumName}' has invalid configuration.",
+			_ => $"Unexpected error for album name '{albumName}'."
+		};
+	}
+
+	[McpServerTool(Name = "list_photos_by_exact_date")]
+	[Description("List photos matching an exact date (year, month, day). All parameters are optional for broader matching.")]
+	public async Task<string> ListPhotosByExactDate(
+		[Description("The year to filter by (e.g. 2023). Optional.")] int? year = null,
+		[Description("The month to filter by (1-12). Optional.")] byte? month = null,
+		[Description("The day to filter by (1-31). Optional.")] byte? day = null)
+	{
+		var photos = await dbService.GetPhotosByDate(year, month, day);
+		return SerializePhotos(photos);
+	}
+
+	[McpServerTool(Name = "list_photos_by_date_range")]
+	[Description("List photo0s within a date range. Both start and end dates are inclusive.")]
+	public async Task<string> ListPhotosByDateRange(
+		[Description("Start date in ISO 8601 format (e.g. 2023-01-01). Optional.")] string? startDate = null,
+		[Description("End date in ISO 8601 format (e.g. 2023-12-31). Optional.")] string? endDate = null)
+	{
+		DateTime? start = !string.IsNullOrWhiteSpace(startDate) && DateTime.TryParse(startDate, out var s) ? s : null;
+		DateTime? end = !string.IsNullOrWhiteSpace(endDate) && DateTime.TryParse(endDate, out var e) ? e : null;
+
+		var photos = await dbService.GetPhotosByDateRange(start, end);
+		return SerializePhotos(photos);
+	}
+
+	[McpServerTool(Name = "open_photos_by_album_id")]
+	[Description("Open photos belonging to an album by its numeric ID in the default viewer (macOS Preview).")]
+	public async Task<string> OpenPhotosByAlbumId(
+		[Description("The numeric ID of the album.")] int albumId)
+	{
+		var albumPhotoResult = await dbService.GetAlbumPhotosById(albumId);
+		return albumPhotoResult.Status switch
+		{
+			AlbumPhotoResultStatus.Successful => await OpenPhotos(albumPhotoResult.Photos),
+			AlbumPhotoResultStatus.AlbumNotFound => $"Album with id {albumId} not found.",
+			AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat => $"Album with id {albumId} has invalid configuration.",
+			_ => $"Unexpected error for album id {albumId}."
+		};
+	}
+
+	[McpServerTool(Name = "open_photos_by_album_name")]
+	[Description("Open photos belonging to an album by its name in the default viewer (macOS Preview).")]
+	public async Task<string> OpenPhotosByAlbumName(
+		[Description("The name of the album.")] string albumName)
+	{
+		var albumPhotoResult = await dbService.GetAlbumPhotosByName(albumName);
+		return albumPhotoResult.Status switch
+		{
+			AlbumPhotoResultStatus.Successful => await OpenPhotos(albumPhotoResult.Photos),
+			AlbumPhotoResultStatus.AlbumNotFound => $"Album with name '{albumName}' not found.",
+			AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat => $"Album with name '{albumName}' has invalid configuration.",
+			_ => $"Unexpected error for album name '{albumName}'."
+		};
+	}
+
+	[McpServerTool(Name = "open_photos_by_exact_date")]
+	[Description("Open photos matching an exact date (year, month, day) in the default viewer (macOS Preview). All parameters are optional for broader matching.")]
+	public async Task<string> OpenPhotosByExactDate(
+		[Description("The year to filter by (e.g. 2023). Optional.")] int? year = null,
+		[Description("The month to filter by (1-12). Optional.")] byte? month = null,
+		[Description("The day to filter by (1-31). Optional.")] byte? day = null)
+	{
+		var photos = await dbService.GetPhotosByDate(year, month, day);
+		return await OpenPhotos(photos);
+	}
+
+	[McpServerTool(Name = "open_photos_by_date_range")]
+	[Description("Open photos within a date range in the default viewer (macOS Preview). Both start and end dates are inclusive.")]
+	public async Task<string> OpenPhotosByDateRange(
+		[Description("Start date in ISO 8601 format (e.g. 2023-01-01). Optional.")] string? startDate = null,
+		[Description("End date in ISO 8601 format (e.g. 2023-12-31). Optional.")] string? endDate = null)
+	{
+		DateTime? start = !string.IsNullOrWhiteSpace(startDate) && DateTime.TryParse(startDate, out var s) ? s : null;
+		DateTime? end = !string.IsNullOrWhiteSpace(endDate) && DateTime.TryParse(endDate, out var e) ? e : null;
+
+		var photos = await dbService.GetPhotosByDateRange(start, end);
+		return await OpenPhotos(photos);
+	}
+
+	private async Task<string> OpenPhotos(List<PhotoEntity> photos)
+	{
+		if (photos.Count == 0)
+			return "No photos found to open.";
+
+		var photoPaths = photos.Select(p => Path.Combine(mcpOptions.ArchivePath, p.Path)).ToList();
+		await processLauncher.Launch(photoPaths);
+		return $"Opened {photos.Count} photo(s) in the default viewer.";
+	}
+
+	private static string SerializePhotos(List<PhotoEntity> photos)
+	{
+		var result = photos.Select(p => new { p.Path, p.DateTaken, p.ReverseGeocodeFormatted, p.Latitude, p.Longitude });
+		return JsonSerializer.Serialize(result, StaticOptions.McpToolOptions);
+	}
+
+	private static bool IsKnownGroupBy(string groupBy) =>
+		groupBy.Trim().ToLowerInvariant() is "year" or "month" or "location" or "address1" or "address2" or "address3" or "address4";
+}

--- a/src/Models/Enums/ExitCode.cs
+++ b/src/Models/Enums/ExitCode.cs
@@ -17,6 +17,7 @@ public enum ExitCode
 	CopyOptionsValidationFailed = 13,
 	SettingsOptionsValidationFailed = 14,
 	ArchiveOptionsValidationFailed = 15,
+	McpOptionsValidationFailed = 16,
 
 	// File system
 	InputFolderNotExists = 20,

--- a/src/Models/Enums/ExitCode.cs
+++ b/src/Models/Enums/ExitCode.cs
@@ -55,4 +55,5 @@ public enum ExitCode
 	// List
 	NoArchiveDatabaseFound = 60,
 	NoPhotoFoundToList = 61,
+	AlbumNotFoundByName = 62,
 }

--- a/src/Models/PhotoNearLocationResult.cs
+++ b/src/Models/PhotoNearLocationResult.cs
@@ -1,0 +1,3 @@
+namespace PhotoCli;
+
+public record PhotoNearLocationResult(string Path, DateTime? DateTaken, string? ReverseGeocodeFormatted, double DistanceKm);

--- a/src/Models/PhotoStatisticsRow.cs
+++ b/src/Models/PhotoStatisticsRow.cs
@@ -1,0 +1,3 @@
+namespace PhotoCli;
+
+public record PhotoStatisticsRow(int? Year, int? Month, string? Location, int Count);

--- a/src/Options/CopyOptions.cs
+++ b/src/Options/CopyOptions.cs
@@ -5,7 +5,7 @@ namespace PhotoCli.Options;
 [Verb(OptionNames.CopyVerb, HelpText = "Copies photos into new folder hierarchy with given arguments using photograph's taken date and coordinate address (reverse geocode).")]
 public class CopyOptions : IActionableReverseGeocodeOptions
 {
-	// Notes: Constructor parameters and properties should be in same order for Immutable Options Type in CommandLineParser.
+	// Notes: Constructor parameters and properties should be in the same order for Immutable Options Type in CommandLineParser.
 	// ref: https://github.com/commandlineparser/commandline/wiki/Immutable-Options-Type
 	public CopyOptions(
 		// Required

--- a/src/Options/HelpTexts.cs
+++ b/src/Options/HelpTexts.cs
@@ -427,6 +427,17 @@ public static class HelpTexts
 
 	#endregion
 
+	#region Mcp
+
+	public const string McpVerbHelpText = "Start an MCP (Model Context Protocol) stdio server to query the photo archive database.";
+
+	public const string McpArchivePath = """
+	                                        Archive folder path containing the photo-cli database to expose via MCP.
+	                                        Default: current executing folder.
+	                                        """;
+
+	#endregion
+
 	#region List
 
 	public const string ArchivePath = """

--- a/src/Options/HelpTexts.cs
+++ b/src/Options/HelpTexts.cs
@@ -452,16 +452,23 @@ public static class HelpTexts
 
 	                               Albums: 1 - Lists all albums with their id, name, type, creation date, and configuration
 
-	                               PhotosByAlbum: 2 - Lists or opens photos belonging to a specific album (requires `--album-id`)
+	                               PhotosByAlbumId: 2 - Lists or opens photos belonging to a specific album by the ID (requires `--id`)
 
-	                               PhotosByDate: 3 - Lists or opens photos filtered by date (optionally filtered by `--year`, `--month`, `--day`)
+	                               PhotosByAlbumName: 3 - Lists or opens photos belonging to a specific album by album name (requires `--name`)
+
+	                               PhotosByExactDate: 4 - Lists or opens photos filtered by date (optionally filtered by `--year`, `--month`, `--day`)
+
+	                               PhotosByDateRange: 5 - Lists or opens photos within a date range (requires `--start-date` and `--end-date`)
 	                               """;
 
-	public const string AlbumId = "(Optional) Album ID to be used while using the list type of `PhotosByAlbum`";
-	public const string Year = "(Optional) Year as number to be used while using the list type of `PhotosByDate`";
-	public const string Month = "(Optional) Month as number to be used while using the list type of `PhotosByDate`";
-	public const string Day = "(Optional) Day as number to be used while using the list type of `PhotosByDate`";
-	public const string RawOutput = "(Optional) Listing photo paths each on new line instead of trying to open the default OS app while using the list type of `PhotosByAlbum` or `PhotosByDate`.";
+	public const string AlbumId = "(Optional) Album ID to be used while using the list type of `PhotosByAlbumId`";
+	public const string AlbumName = "(Optional) Album name to be used while using the list type of `PhotosByAlbumName`";
+	public const string Year = "(Optional) Year as number to be used while using the list type of `PhotosByExactDate`";
+	public const string Month = "(Optional) Month as number to be used while using the list type of `PhotosByExactDate`";
+	public const string Day = "(Optional) Day as number to be used while using the list type of `PhotosByExactDate`";
+	public const string StartDate = "(Optional) Start date (inclusive) to be used while using the list type of `PhotosByDateRange`";
+	public const string EndDate = "(Optional) End date (inclusive) to be used while using the list type of `PhotosByDateRange`";
+	public const string RawOutput = "(Optional) Listing photo paths each on new line instead of trying to open the default OS app while using the list type of `PhotosByAlbum` or `PhotosByExactDate`.";
 
 	#endregion
 }

--- a/src/Options/ListOptions.cs
+++ b/src/Options/ListOptions.cs
@@ -11,7 +11,11 @@ public class ListOptions
 		// Required
 		ListType listType,
 		// Optional
-		string? archivePath, int? albumId = null, int? year = null, byte? month = null, byte? day = null, bool rawOutput = false)
+		string? archivePath,
+		int? albumId = null, string? albumName = null,
+		int? year = null, byte? month = null, byte? day = null,
+		DateTime? startDate = null, DateTime? endDate = null,
+		bool rawOutput = false)
 	{
 		// Required
 		ListType = listType;
@@ -19,9 +23,12 @@ public class ListOptions
 		// Optional
 		ArchivePath = archivePath ?? Environment.CurrentDirectory;
 		AlbumId = albumId;
+		AlbumName = albumName;
 		Year = year;
 		Month = month;
 		Day = day;
+		StartDate = startDate;
+		EndDate = endDate;
 		RawOutput = rawOutput;
 	}
 
@@ -40,6 +47,9 @@ public class ListOptions
 	[Option(OptionNames.AlbumIdShort, OptionNames.AlbumIdLong, HelpText = HelpTexts.AlbumId)]
 	public int? AlbumId { get; }
 
+	[Option(OptionNames.AlbumNameShort, OptionNames.AlbumNameLong, HelpText = HelpTexts.AlbumName)]
+	public string? AlbumName { get; }
+
 	[Option(OptionNames.YearShort, OptionNames.YearLong, HelpText = HelpTexts.Year)]
 	public int? Year { get; }
 
@@ -48,6 +58,12 @@ public class ListOptions
 
 	[Option(OptionNames.DayShort, OptionNames.DayLong, HelpText = HelpTexts.Day)]
 	public byte? Day { get; }
+
+	[Option(OptionNames.StartDateShort, OptionNames.StartDateLong, HelpText = HelpTexts.StartDate)]
+	public DateTime? StartDate { get; }
+
+	[Option(OptionNames.EndDateShort, OptionNames.EndDateLong, HelpText = HelpTexts.EndDate)]
+	public DateTime? EndDate { get; }
 
 	[Option(OptionNames.RawOutputShort, OptionNames.RawOutputLong, HelpText = HelpTexts.RawOutput)]
 	public bool RawOutput { get; }

--- a/src/Options/ListType.cs
+++ b/src/Options/ListType.cs
@@ -4,6 +4,8 @@ public enum ListType : byte
 {
 	Summary = 0,
 	Albums = 1,
-	PhotosByAlbum = 2,
-	PhotosByDate = 3,
+	PhotosByAlbumId = 2,
+	PhotosByAlbumName = 3,
+	PhotosByExactDate = 4,
+	PhotosByDateRange = 5,
 }

--- a/src/Options/McpOptions.cs
+++ b/src/Options/McpOptions.cs
@@ -1,0 +1,17 @@
+using CommandLine;
+
+namespace PhotoCli.Options;
+
+[Verb(OptionNames.McpVerb, HelpText = HelpTexts.McpVerbHelpText)]
+public class McpOptions
+{
+	// Notes: Constructor parameters and properties should be in the same order for Immutable Options Type in CommandLineParser.
+	// ref: https://github.com/commandlineparser/commandline/wiki/Immutable-Options-Type
+	public McpOptions(string? archivePath = null)
+	{
+		ArchivePath = archivePath ?? Environment.CurrentDirectory;
+	}
+
+	[Option(OptionNames.ArchivePathOptionNameShort, OptionNames.ArchivePathOptionNameLong, HelpText = HelpTexts.McpArchivePath)]
+	public string ArchivePath { get; }
+}

--- a/src/Options/OptionNames.cs
+++ b/src/Options/OptionNames.cs
@@ -39,6 +39,7 @@ internal static class OptionNames
 	internal const string SettingsVerb = "settings";
 	internal const string ArchiveVerb = "archive";
 	internal const string ListVerb = "list";
+	internal const string McpVerb = "mcp";
 
 	#region Copy
 

--- a/src/Options/OptionNames.cs
+++ b/src/Options/OptionNames.cs
@@ -3,11 +3,11 @@ namespace PhotoCli.Options;
 internal static class OptionNames
 {
 	/* Short Option Name Usages
-		a - copy, info, archive
+		a - copy, info, archive, list
 		b - copy, info, address, archive
 		c - copy, info, archive
 		d - copy, archive
-		e - copy, info, address, archive
+		e - copy, info, address, archive, list
 		f - copy, archive
 		g - copy
 		h - copy, info, archive
@@ -16,12 +16,12 @@ internal static class OptionNames
 		k - copy, info, address, settings, archive
 		l - copy, info, address, archive
 		m - copy, info, address, archive
-		n - copy
+		n - copy, list
 		o - copy, info, archive
 		p - copy, archive
 		q - copy, info, address, archive
 		r - copy, info, address, settings, archive
-		s - copy, archive
+		s - copy, archive, list
 		t - copy, info, address, archive, list
 		u - copy, info, address, archive
 		v - copy, settings
@@ -215,6 +215,9 @@ internal static class OptionNames
 	internal const char AlbumIdShort = 'n';
 	internal const string AlbumIdLong = "id";
 
+	internal const char AlbumNameShort = 'a';
+	internal const string AlbumNameLong = "name";
+
 	internal const char YearShort = 'y';
 	internal const string YearLong = "year";
 
@@ -226,6 +229,12 @@ internal static class OptionNames
 
 	internal const char RawOutputShort = 'r';
 	internal const string RawOutputLong = "raw";
+
+	internal const char StartDateShort = 's';
+	internal const string StartDateLong = "start-date";
+
+	internal const char EndDateShort = 'e';
+	internal const string EndDateLong = "end-date";
 
 	#endregion
 }

--- a/src/Options/Validators/BaseValidator.cs
+++ b/src/Options/Validators/BaseValidator.cs
@@ -26,6 +26,11 @@ public abstract class BaseValidator<T> : AbstractValidator<T>
 		return $"Can't find {reverseGeocodeProvider} API key at environment variable with key {environmentVariableKey} or application arguments -{longOptionName} or -{shortOptionName}";
 	}
 
+	protected string MustProvideAtLeastOneOfWhen(string when, params string[] options)
+	{
+		return $"Must provide at least one of {string.Join(" or ", options)} when using {when}";
+	}
+
 	protected string MustAlsoUseOnlyOneOfTheOptions(params string[] options)
 	{
 		return $"Must use only one of the options {string.Join(", ", options)}";

--- a/src/Options/Validators/ListOptionsValidator.cs
+++ b/src/Options/Validators/ListOptionsValidator.cs
@@ -6,5 +6,22 @@ public class ListOptionsValidator : BaseValidator<ListOptions>
 {
 	public ListOptionsValidator()
 	{
+		RuleFor(r => r.ListType).ValidEnum(true);
+
+		When(w => w.ListType is ListType.PhotosByAlbumId, () =>
+		{
+			RuleFor(r => r.AlbumId).NotNull().WithMessage(MustUseMessage(nameof(ListOptions.AlbumId), nameof(ListType.PhotosByAlbumId)));
+		});
+
+		When(w => w.ListType is ListType.PhotosByAlbumName, () =>
+		{
+			RuleFor(r => r.AlbumName).NotNull().WithMessage(MustUseMessage(nameof(ListOptions.AlbumName), nameof(ListType.PhotosByAlbumName)));
+		});
+
+		When(w => w.ListType is ListType.PhotosByDateRange, () =>
+		{
+			RuleFor(r => r).Must(r => r.StartDate.HasValue || r.EndDate.HasValue)
+				.WithMessage(MustProvideAtLeastOneOfWhen(nameof(ListType.PhotosByDateRange), nameof(ListOptions.StartDate), nameof(ListOptions.EndDate)));
+		});
 	}
 }

--- a/src/Options/Validators/McpOptionsValidator.cs
+++ b/src/Options/Validators/McpOptionsValidator.cs
@@ -1,0 +1,3 @@
+namespace PhotoCli.Options.Validators;
+
+public class McpOptionsValidator : BaseValidator<McpOptions>;

--- a/src/PhotoCli.csproj
+++ b/src/PhotoCli.csproj
@@ -38,6 +38,7 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
         <PackageReference Include="Spectre.Console" Version="0.54.0" />
         <PackageReference Include="System.IO.Abstractions" Version="22.1.0" />
+        <PackageReference Include="ModelContextProtocol" Version="1.0.0" />
         <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.0" />
     </ItemGroup>
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -28,7 +28,9 @@ global using PhotoCli.Models.ReverseGeocode;
 using System.IO.Abstractions;
 using CommandLine;
 using FluentValidation;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Http.Resilience;
+using PhotoCli.McpTools;
 using PhotoCli.Utils.Logging;
 using Polly;
 using Spectre.Console;
@@ -117,6 +119,16 @@ public static class Program
 					}
 					host = BuildHost<ListRunner, ListOptions>(listOptions, ansiConsole, new ArchiveDatabaseOptions(listOptions.ArchivePath));
 					break;
+				}
+			case McpOptions mcpOptions:
+				{
+					var validationResultMcp = new McpOptionsValidator().Validate(mcpOptions);
+					if (!validationResultMcp.IsValid)
+					{
+						WriteErrorOutputValidationErrors(validationResultMcp);
+						return ReturnExitCode(ExitCode.McpOptionsValidationFailed);
+					}
+					return RunMcpServer(mcpOptions);
 				}
 			default:
 				throw new PhotoCliException($"Not defined: {baseOptions}");
@@ -325,7 +337,7 @@ public static class Program
 
 	private static bool ParseArgs(IReadOnlyList<string> args, out object parsedObject, out ExitCode exitCode, IAnsiConsole ansiConsole)
 	{
-		var commandLineArgsParsed = Parser.Default.ParseArguments<CopyOptions, InfoOptions, ArchiveOptions, AddressOptions, SettingsOptions, ListOptions>(args);
+		var commandLineArgsParsed = Parser.Default.ParseArguments<CopyOptions, InfoOptions, ArchiveOptions, AddressOptions, SettingsOptions, ListOptions, McpOptions>(args);
 		if (commandLineArgsParsed.Tag == ParserResultType.NotParsed)
 		{
 			var notParsedResult = (NotParsed<object>)commandLineArgsParsed;
@@ -363,5 +375,28 @@ public static class Program
 	private static Task<int> ReturnExitCode(ExitCode exitCode)
 	{
 		return Task.FromResult((int)exitCode);
+	}
+
+	private static async Task<int> RunMcpServer(McpOptions options)
+	{
+		var dbPath = Path.Combine(options.ArchivePath, Constants.ArchiveSQLiteDatabaseFileName);
+		var builder = Host.CreateApplicationBuilder();
+		builder.Logging.ClearProviders();
+		builder.Services.AddDbContext<ArchiveDbContext>(o => o.UseSqlite($"Data Source={dbPath}"));
+		builder.Services.AddScoped<IArchiveDbContextProvider, McpArchiveDbContextProvider>();
+		builder.Services.AddSingleton(ToolOptions.Default());
+		builder.Services.AddSingleton(options);
+		builder.Services.AddSingleton(new Statistics());
+		builder.Services.AddSingleton<IConsoleWriter, NullConsoleWriter>();
+		builder.Services.AddSingleton<IProcessLauncher, ProcessLauncher>();
+		builder.Services.AddScoped<IDbService, DbService>();
+
+		builder.Services
+			.AddMcpServer()
+			.WithStdioServerTransport()
+			.WithTools<ArchiveMcpTools>();
+
+		await builder.Build().RunAsync();
+		return (int)ExitCode.Success;
 	}
 }

--- a/src/Properties/launchSettings.json
+++ b/src/Properties/launchSettings.json
@@ -9,6 +9,10 @@
       "commandLineArgs": "list",
       "commandName": "Project"
     },
+    "mcp": {
+      "commandLineArgs": "mcp",
+      "commandName": "Project"
+    },
     "copy": {
       "commandLineArgs": "copy",
       "commandName": "Project"

--- a/src/Runners/ListRunner.cs
+++ b/src/Runners/ListRunner.cs
@@ -40,10 +40,14 @@ public class ListRunner : BaseRunner, IConsoleRunner
 				return await Summary();
 			case ListType.Albums:
 				return await Albums();
-			case ListType.PhotosByAlbum:
-				return await PhotoByAlbums(archivePath);
-			case ListType.PhotosByDate:
-				return await PhotoByDate(archivePath);
+			case ListType.PhotosByAlbumId:
+				return await PhotoByAlbumId(archivePath);
+			case ListType.PhotosByAlbumName:
+				return await PhotoByAlbumName(archivePath);
+			case ListType.PhotosByExactDate:
+				return await PhotoByExactDate(archivePath);
+			case ListType.PhotosByDateRange:
+				return await PhotoByDateRange(archivePath);
 			default:
 				throw new PhotoCliException();
 		}
@@ -94,33 +98,52 @@ public class ListRunner : BaseRunner, IConsoleRunner
 		return ExitCode.Success;
 	}
 
-	private async Task<ExitCode> PhotoByAlbums(string inputArchivePath)
+	private async Task<ExitCode> PhotoByAlbumId(string inputArchivePath)
 	{
 		if (!_options.AlbumId.HasValue)
 			throw new PhotoCliException("Album id is required to list photos by albums");
 
 		var albumPhotoResult = await _dbService.GetAlbumPhotosById(_options.AlbumId.Value);
-
 		if (albumPhotoResult.Status == AlbumPhotoResultStatus.Successful)
-		{
-			return await Run(albumPhotoResult.Photos, inputArchivePath);
-		}
-		var exitCode = albumPhotoResult.Status switch
+			return await ListPhotos(albumPhotoResult.Photos, inputArchivePath);
+		return albumPhotoResult.Status switch
 		{
 			AlbumPhotoResultStatus.AlbumNotFound => ExitCode.AlbumNotFoundById,
 			AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat => ExitCode.ExistingAlbumConfigurationNotValid,
-			_ => throw new PhotoCliException($"Not defined album photo result on {nameof(PhotoByAlbums)} for {nameof(AlbumPhotoResultStatus)}: {albumPhotoResult.Status}")
+			_ => throw new PhotoCliException($"Not defined album photo result on {nameof(PhotoByAlbumId)} for {nameof(AlbumPhotoResultStatus)}: {albumPhotoResult.Status}")
 		};
-		return exitCode;
 	}
 
-	private async Task<ExitCode> PhotoByDate(string inputArchivePath)
+	private async Task<ExitCode> PhotoByAlbumName(string inputArchivePath)
+	{
+		if (_options.AlbumName == null)
+			throw new PhotoCliException("Album id or album name is required to list photos by albums");
+
+		var albumPhotoResult = await _dbService.GetAlbumPhotosByName(_options.AlbumName);
+		if (albumPhotoResult.Status == AlbumPhotoResultStatus.Successful)
+			return await ListPhotos(albumPhotoResult.Photos, inputArchivePath);
+		return albumPhotoResult.Status switch
+		{
+			AlbumPhotoResultStatus.AlbumNotFound => ExitCode.AlbumNotFoundByName,
+			AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat => ExitCode.ExistingAlbumConfigurationNotValid,
+			_ => throw new PhotoCliException($"Not defined album photo result on {nameof(PhotoByAlbumId)} for {nameof(AlbumPhotoResultStatus)}: {albumPhotoResult.Status}")
+		};
+
+	}
+
+	private async Task<ExitCode> PhotoByExactDate(string inputArchivePath)
 	{
 		var photos = await _dbService.GetPhotosByDate(_options.Year, _options.Month, _options.Day);
-		return await Run(photos, inputArchivePath);
+		return await ListPhotos(photos, inputArchivePath);
 	}
 
-	private async Task<ExitCode> Run(List<PhotoEntity> photos, string inputArchivePath)
+	private async Task<ExitCode> PhotoByDateRange(string inputArchivePath)
+	{
+		var photos = await _dbService.GetPhotosByDateRange(_options.StartDate, _options.EndDate);
+		return await ListPhotos(photos, inputArchivePath);
+	}
+
+	private async Task<ExitCode> ListPhotos(List<PhotoEntity> photos, string inputArchivePath)
 	{
 		if (photos.Count == 0)
 		{

--- a/src/Services/Contracts/IDbService.cs
+++ b/src/Services/Contracts/IDbService.cs
@@ -11,7 +11,9 @@ public interface IDbService
 	Task<TResponse?> GetReverseGeocodeCache<TResponse>(ReverseGeocodeRequest request, ReverseGeocodeProvider provider);
 	Task SaveReverseGeocodeCache<TResponse>(ReverseGeocodeRequest request, TResponse response, ReverseGeocodeProvider provider);
 	Task<AlbumPhotoResult> GetAlbumPhotosById(int albumId);
+	Task<AlbumPhotoResult> GetAlbumPhotosByName(string name);
 	Task<List<PhotoEntity>> GetPhotosByDate(int? year, byte? month, byte? day);
+	Task<List<PhotoEntity>> GetPhotosByDateRange(DateTime? start, DateTime? end);
 	Task<AlbumEntity?> GetAlbumByName(string name);
 	Task<AlbumEntity?> GetAlbumById(int albumId);
 	Task<List<AlbumEntity>> GetAllAlbums();

--- a/src/Services/Contracts/IDbService.cs
+++ b/src/Services/Contracts/IDbService.cs
@@ -18,4 +18,8 @@ public interface IDbService
 	Task<int> TotalAlbumCount();
 	Task<long> TotalPhotoCount();
 	Task<long> TotalReverseGeocodeCacheCount();
+	Task<List<PhotoEntity>> SearchPhotos(DateTime? start, DateTime? end, string? location, int limit);
+	Task<PhotoEntity?> GetPhotoByPath(string filePath);
+	Task<List<PhotoStatisticsRow>> GetPhotoStatistics(string groupBy);
+	Task<List<PhotoNearLocationResult>> FindPhotosNearLocation(double latitude, double longitude, double radiusKm, int limit);
 }

--- a/src/Services/Implementations/DbService.cs
+++ b/src/Services/Implementations/DbService.cs
@@ -460,6 +460,115 @@ public class DbService : IDbService
 			.ToList()!;
 	}
 
+	public async Task<List<PhotoEntity>> SearchPhotos(DateTime? start, DateTime? end, string? location, int limit)
+	{
+		var query = _archiveDbContext.Photos.Where(p => !p.IsDeleted);
+
+		if (start.HasValue)
+			query = query.Where(p => p.DateTaken >= start);
+
+		if (end.HasValue)
+			query = query.Where(p => p.DateTaken <= end.Value.AddDays(1).AddTicks(-1));
+
+		if (!string.IsNullOrWhiteSpace(location))
+			query = query.Where(p => p.ReverseGeocodeFormatted != null && EF.Functions.Like(p.ReverseGeocodeFormatted, $"%{location}%"));
+
+		return await query
+			.OrderByDescending(p => p.DateTaken)
+			.Take(limit)
+			.ToListAsync();
+	}
+
+	public async Task<PhotoEntity?> GetPhotoByPath(string filePath)
+	{
+		return await _archiveDbContext.Photos
+			.Where(p => p.Path == filePath && !p.IsDeleted)
+			.FirstOrDefaultAsync();
+	}
+
+	public async Task<List<PhotoStatisticsRow>> GetPhotoStatistics(string groupBy)
+	{
+		var lowerGroup = groupBy.Trim().ToLowerInvariant();
+
+		if (lowerGroup == "year")
+		{
+			var rows = await _archiveDbContext.Photos
+				.Where(p => !p.IsDeleted && p.Year != null)
+				.GroupBy(p => p.Year)
+				.Select(g => new { Year = g.Key, Count = g.Count() })
+				.OrderBy(r => r.Year)
+				.ToListAsync();
+			return rows.Select(r => new PhotoStatisticsRow(r.Year, null, null, r.Count)).ToList();
+		}
+
+		if (lowerGroup == "month")
+		{
+			var rows = await _archiveDbContext.Photos
+				.Where(p => !p.IsDeleted && p.Year != null && p.Month != null)
+				.GroupBy(p => new { p.Year, p.Month })
+				.Select(g => new { g.Key.Year, g.Key.Month, Count = g.Count() })
+				.OrderBy(r => r.Year).ThenBy(r => r.Month)
+				.ToListAsync();
+			return rows.Select(r => new PhotoStatisticsRow(r.Year, r.Month, null, r.Count)).ToList();
+		}
+
+		Func<PhotoEntity, string?> addressSelector = lowerGroup switch
+		{
+			"location" or "address1" => p => p.Address1,
+			"address2" => p => p.Address2,
+			"address3" => p => p.Address3,
+			"address4" => p => p.Address4,
+			_ => null!,
+		};
+
+		if (addressSelector != null)
+		{
+			var photos = await _archiveDbContext.Photos
+				.Where(p => !p.IsDeleted)
+				.ToListAsync();
+			return photos
+				.GroupBy(addressSelector)
+				.Where(g => !string.IsNullOrEmpty(g.Key))
+				.OrderByDescending(g => g.Count())
+				.Select(g => new PhotoStatisticsRow(null, null, g.Key, g.Count()))
+				.ToList();
+		}
+
+		return [];
+	}
+
+	public async Task<List<PhotoNearLocationResult>> FindPhotosNearLocation(double latitude, double longitude, double radiusKm, int limit)
+	{
+		var photos = await _archiveDbContext.Photos
+			.Where(p => !p.IsDeleted && p.Latitude != null && p.Longitude != null)
+			.Select(p => new { p.Path, p.DateTaken, p.Latitude, p.Longitude, p.ReverseGeocodeFormatted })
+			.ToListAsync();
+
+		return photos
+			.Select(p => new PhotoNearLocationResult(
+				p.Path,
+				p.DateTaken,
+				p.ReverseGeocodeFormatted,
+				Math.Round(HaversineKm(latitude, longitude, p.Latitude!.Value, p.Longitude!.Value), 3)))
+			.Where(p => p.DistanceKm <= radiusKm)
+			.OrderBy(p => p.DistanceKm)
+			.Take(limit)
+			.ToList();
+	}
+
+	private static double HaversineKm(double lat1, double lon1, double lat2, double lon2)
+	{
+		const double earthRadiusKm = 6371.0;
+		var dLat = ToRad(lat2 - lat1);
+		var dLon = ToRad(lon2 - lon1);
+		var a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2)
+		        + Math.Cos(ToRad(lat1)) * Math.Cos(ToRad(lat2))
+		        * Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+		return earthRadiusKm * 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+	}
+
+	private static double ToRad(double degrees) => degrees * Math.PI / 180.0;
+
 	private static string? GetPropertyStringValueOrDefault(PhotoEntity photo, string propertyName)
 	{
 		var property = typeof(PhotoEntity).GetProperty(propertyName);

--- a/src/Services/Implementations/DbService.cs
+++ b/src/Services/Implementations/DbService.cs
@@ -307,6 +307,18 @@ public class DbService : IDbService
 		return _archiveDbContext.ReverseGeocodeCache.LongCountAsync();
 	}
 
+	public async Task<AlbumPhotoResult> GetAlbumPhotosByName(string name)
+	{
+		var album = await GetAlbumByName(name);
+		if (album == null)
+		{
+			_logger.LogError("Album with name, {AlbumName} not found", name);
+			return new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, []);
+		}
+
+		return await GetAlbumPhotos(album);
+	}
+
 	public async Task<AlbumPhotoResult> GetAlbumPhotosById(int albumId)
 	{
 		var album = await GetAlbumById(albumId);
@@ -316,9 +328,14 @@ public class DbService : IDbService
 			return new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, []);
 		}
 
+		return await GetAlbumPhotos(album);
+	}
+
+	private async Task<AlbumPhotoResult> GetAlbumPhotos(AlbumEntity album)
+	{
 		if (!DeserializeConfiguration<AlbumConfiguration>(album.Configuration, out var configuration))
 		{
-			_logger.LogCritical("Album with id, {AlbumId} configuration is not a valid json, manually fix from history, configuration raw {Configuration}", albumId, album.Configuration);
+			_logger.LogCritical("Album {AlbumId} ({AlbumName}) configuration is not a valid json, manually fix from history, configuration raw {Configuration}", album.Id, album.Name, album.Configuration);
 			return new AlbumPhotoResult(AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat, []);
 		}
 
@@ -350,14 +367,26 @@ public class DbService : IDbService
 
 	public Task<List<PhotoEntity>> GetPhotosByDate(int? year, byte? month, byte? day)
 	{
-		var query = _archiveDbContext.Photos.Where(p => !p.IsDeleted);
+		var query = _archiveDbContext.Photos.Where(w => !w.IsDeleted);
 
 		if (year != null)
-			query = query.Where(p => p.Year == year.Value);
+			query = query.Where(w => w.Year == year.Value);
 		if (month != null)
-			query = query.Where(p => p.Month == month.Value);
+			query = query.Where(w => w.Month == month.Value);
 		if (day != null)
-			query = query.Where(p => p.Day == day.Value);
+			query = query.Where(w => w.Day == day.Value);
+
+		return query.ToListAsync();
+	}
+
+	public Task<List<PhotoEntity>> GetPhotosByDateRange(DateTime? start, DateTime? end)
+	{
+		var query = _archiveDbContext.Photos.Where(p => !p.IsDeleted);
+
+		if (start.HasValue)
+			query = query.Where(w => w.DateTaken >= start);
+		if (end.HasValue)
+			query = query.Where(w => w.DateTaken <= end.Value.AddDays(1).AddTicks(-1));
 
 		return query.ToListAsync();
 	}

--- a/src/Services/Implementations/McpArchiveDbContextProvider.cs
+++ b/src/Services/Implementations/McpArchiveDbContextProvider.cs
@@ -1,0 +1,6 @@
+namespace PhotoCli.Services.Implementations;
+
+public class McpArchiveDbContextProvider(ArchiveDbContext context) : IArchiveDbContextProvider
+{
+	public ArchiveDbContext CreateOrGetInstance() => context;
+}

--- a/src/Services/Implementations/NullConsoleWriter.cs
+++ b/src/Services/Implementations/NullConsoleWriter.cs
@@ -1,0 +1,17 @@
+using Spectre.Console;
+
+namespace PhotoCli.Services.Implementations;
+
+public class NullConsoleWriter : IConsoleWriter
+{
+	public void Write(string message) { }
+	public void WriteJson(string message) { }
+	public void WriteSuccess(string message) { }
+	public void WriteError(string message) { }
+	public void ProgressStart(string name, int? totalCount = null) { }
+	public void InProgressItemComplete(string name, string? additionalInformation = null) { }
+	public void ProgressFinish(string name, string? additionalInformation = "") { }
+	public void InitializeSpectreContext(StatusContext specterStatusContext) { }
+	public void WriteTable(Table table) { }
+	public void RawWriteLine(string value) { }
+}

--- a/src/Utils/HelpTextBuilder.cs
+++ b/src/Utils/HelpTextBuilder.cs
@@ -141,7 +141,7 @@ public static class HelpTextBuilder
 	public static void ExtendedHelpWritingToConsole(IAnsiConsole ansiConsole)
 	{
 		var ansiConsoleExtended = new AnsiConsoleExtended(ansiConsole);
-		var verbs = new[] { OptionNames.CopyVerb, OptionNames.InfoVerb, OptionNames.AddressVerb, OptionNames.SettingsVerb };
+		var verbs = new[] { OptionNames.CopyVerb, OptionNames.InfoVerb, OptionNames.AddressVerb, OptionNames.SettingsVerb, OptionNames.McpVerb };
 		ansiConsoleExtended.WriteLine($"Type `{OptionNames.ApplicationAlias} help ({string.Join('|', verbs)})` for detailed option list and example usages");
 	}
 }

--- a/src/Utils/HelpTextBuilder.cs
+++ b/src/Utils/HelpTextBuilder.cs
@@ -124,7 +124,7 @@ public static class HelpTextBuilder
 
 				WriteOptionArgumentsToConsole(ansiConsoleExtended,
 					"list --type PhotosByDateRange --start-date 2025-09-21 --end-date 2026-01-30 --input (input-folder)",
-					"list -t PhotosByDateRange -s 2025-09-21 -e 2026-01-30 -input (input-folder)",
+					"list -t PhotosByDateRange -s 2025-09-21 -e 2026-01-30 -i (input-folder)",
 					"List paths (to be send as process arguments to photo viewers) or " +
 					"open (only supporting in macOS , Preview app for now) for photos taken within the given date range");
 

--- a/src/Utils/HelpTextBuilder.cs
+++ b/src/Utils/HelpTextBuilder.cs
@@ -106,21 +106,27 @@ public static class HelpTextBuilder
 				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.Summary, inputFolder), "List statistics of the archive folder");
 				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.Albums, inputFolder), "List all the album information of the archive folder");
 
-				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByAlbum, inputFolder, 1),
+				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByAlbumId, inputFolder, 1),
 					"List paths (to be send as process arguments to photo viewers) or " +
 					"open (only supporting in macOS , Preview app for now) for the given album id");
 
-				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByDate, inputFolder, year: 2007),
+				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByExactDate, inputFolder, year: 2007),
 					"List paths (to be send as process arguments to photo viewers) or " +
 					"open (only supporting in macOS , Preview app for now) for the given year");
 
-				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByDate, inputFolder, year: 2007, month: 8),
+				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByExactDate, inputFolder, year: 2007, month: 8),
 					"List paths (to be send as process arguments to photo viewers) or " +
 					"open (only supporting in macOS , Preview app for now) for the given year & month");
 
-				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByDate, inputFolder, year: 2007, month: 8, day: 19),
+				WriteOptionArgumentsToConsole(ansiConsoleExtended, new ListOptions(ListType.PhotosByExactDate, inputFolder, year: 2007, month: 8, day: 19),
 					"List paths (to be send as process arguments to photo viewers) or " +
 					"open (only supporting in macOS , Preview app for now) for the given year, month & day");
+
+				WriteOptionArgumentsToConsole(ansiConsoleExtended,
+					"list --type PhotosByDateRange --start-date 2025-09-21 --end-date 2026-01-30 --input (input-folder)",
+					"list -t PhotosByDateRange -s 2025-09-21 -e 2026-01-30 -input (input-folder)",
+					"List paths (to be send as process arguments to photo viewers) or " +
+					"open (only supporting in macOS , Preview app for now) for photos taken within the given date range");
 
 				break;
 		}
@@ -128,13 +134,21 @@ public static class HelpTextBuilder
 
 	private static void WriteOptionArgumentsToConsole<TOptions>(AnsiConsoleExtended ansiConsoleExtended, TOptions options, string description)
 	{
+		WriteOptionArgumentsToConsole(ansiConsoleExtended,
+			Parser.Default.FormatCommandLine(options),
+			Parser.Default.FormatCommandLine(options, settings => settings.PreferShortName = true),
+			description);
+	}
+
+	private static void WriteOptionArgumentsToConsole(AnsiConsoleExtended ansiConsoleExtended, string commandWithLongArguments, string commandWithShortArguments, string description)
+	{
 		ansiConsoleExtended.WriteLine($"- {description}");
 		ansiConsoleExtended.EmptyLine();
 		ansiConsoleExtended.WriteLine("Example with long argument names;");
-		ansiConsoleExtended.WriteLine($"{OptionNames.ApplicationAlias} {Parser.Default.FormatCommandLine(options)}");
+		ansiConsoleExtended.WriteLine($"{OptionNames.ApplicationAlias} {commandWithLongArguments}");
 		ansiConsoleExtended.EmptyLine();
 		ansiConsoleExtended.WriteLine("Example with short argument names;");
-		ansiConsoleExtended.WriteLine($"{OptionNames.ApplicationAlias} {Parser.Default.FormatCommandLine(options, settings => settings.PreferShortName = true)}");
+		ansiConsoleExtended.WriteLine($"{OptionNames.ApplicationAlias} {commandWithShortArguments}");
 		ansiConsoleExtended.EmptyLine();
 	}
 

--- a/src/Utils/Logging/AnsiConsoleLogger.cs
+++ b/src/Utils/Logging/AnsiConsoleLogger.cs
@@ -104,6 +104,9 @@ public class AnsiConsoleLogger : ILogger
 		if (_logCategoryNameOutput)
 			logContent += $" on ({_ansiConsoleExtended.OutputTextByFormat(_categoryName, Color.Grey)})";
 
+		if (exception != null)
+			logContent += Environment.NewLine + _ansiConsoleExtended.EscapeMarkup(exception.ToString());
+
 		_ansiConsoleExtended.WriteLineWithTime(logContent, spectreFormat);
 	}
 	public bool IsEnabled(LogLevel logLevel)

--- a/src/Utils/StaticOptions.cs
+++ b/src/Utils/StaticOptions.cs
@@ -19,4 +19,9 @@ public static class StaticOptions
 	{
 		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
 	};
+
+	public static readonly JsonSerializerOptions McpToolOptions = new()
+	{
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	};
 }

--- a/tests/EndToEndTests/HelpVerbEndToEndTests.cs
+++ b/tests/EndToEndTests/HelpVerbEndToEndTests.cs
@@ -232,34 +232,42 @@ photo-cli list -i (input-folder) -t Albums
 - List paths (to be send as process arguments to photo viewers) or open (only supporting in macOS , Preview app for now) for the given album id
 
 Example with long argument names;
-photo-cli list --input (input-folder) --id 1 --type PhotosByAlbum
+photo-cli list --input (input-folder) --id 1 --type PhotosByAlbumId
 
 Example with short argument names;
-photo-cli list -i (input-folder) -n 1 -t PhotosByAlbum
+photo-cli list -i (input-folder) -n 1 -t PhotosByAlbumId
 
 - List paths (to be send as process arguments to photo viewers) or open (only supporting in macOS , Preview app for now) for the given year
 
 Example with long argument names;
-photo-cli list --input (input-folder) --type PhotosByDate --year 2007
+photo-cli list --input (input-folder) --type PhotosByExactDate --year 2007
 
 Example with short argument names;
-photo-cli list -i (input-folder) -t PhotosByDate -y 2007
+photo-cli list -i (input-folder) -t PhotosByExactDate -y 2007
 
 - List paths (to be send as process arguments to photo viewers) or open (only supporting in macOS , Preview app for now) for the given year & month
 
 Example with long argument names;
-photo-cli list --input (input-folder) --month 8 --type PhotosByDate --year 2007
+photo-cli list --input (input-folder) --month 8 --type PhotosByExactDate --year 2007
 
 Example with short argument names;
-photo-cli list -i (input-folder) -m 8 -t PhotosByDate -y 2007
+photo-cli list -i (input-folder) -m 8 -t PhotosByExactDate -y 2007
 
 - List paths (to be send as process arguments to photo viewers) or open (only supporting in macOS , Preview app for now) for the given year, month & day
 
 Example with long argument names;
-photo-cli list --day 19 --input (input-folder) --month 8 --type PhotosByDate --year 2007
+photo-cli list --day 19 --input (input-folder) --month 8 --type PhotosByExactDate --year 2007
 
 Example with short argument names;
-photo-cli list -d 19 -i (input-folder) -m 8 -t PhotosByDate -y 2007";
+photo-cli list -d 19 -i (input-folder) -m 8 -t PhotosByExactDate -y 2007
+
+- List paths (to be send as process arguments to photo viewers) or open (only supporting in macOS , Preview app for now) for photos taken within the given date range
+
+Example with long argument names;
+photo-cli list --type PhotosByDateRange --start-date 2025-09-21 --end-date 2026-01-30 --input (input-folder)
+
+Example with short argument names;
+photo-cli list -t PhotosByDateRange -s 2025-09-21 -e 2026-01-30 -i (input-folder)";
 		await RunHelpAndVerifyOutput("list", archiveExampleUsages);
 	}
 

--- a/tests/EndToEndTests/HelpVerbEndToEndTests.cs
+++ b/tests/EndToEndTests/HelpVerbEndToEndTests.cs
@@ -2,7 +2,7 @@ namespace PhotoCli.Tests.EndToEndTests;
 
 public class HelpVerbEndToEndTests : BaseEndToEndTests
 {
-	private const string DefaultHelpText = "Type `photo-cli help (copy|info|address|settings)` for detailed option list and example usages";
+	private const string DefaultHelpText = "Type `photo-cli help (copy|info|address|settings|mcp)` for detailed option list and example usages";
 
 	[Fact]
 	public async Task Running_Without_Arguments_Should_Output_Custom_Help_Text()

--- a/tests/EndToEndTests/ListVerbEndToEndTests.cs
+++ b/tests/EndToEndTests/ListVerbEndToEndTests.cs
@@ -128,7 +128,7 @@ public class ListVerbEndToEndTests : BaseEndToEndTests
 	public static TheoryData<ICollection<string>, string[]> DateRangeAlbumPhotosWithExpectedFilePaths = new()
 	{
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbum, TestImagesPathHelper.ArchiveFolder(), 1, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbumId, TestImagesPathHelper.ArchiveFolder(), 1, rawOutput: true),
 			ItalyArezzoPhotos
 		}
 	};
@@ -136,19 +136,19 @@ public class ListVerbEndToEndTests : BaseEndToEndTests
 	public static TheoryData<ICollection<string>, string[]> ReverseGeocodeAlbumPhotosWithExpectedFilePaths = new()
 	{
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbum, TestImagesPathHelper.ArchiveFolder(), 2, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbumId, TestImagesPathHelper.ArchiveFolder(), 2, rawOutput: true),
 			ItalyArezzoPhotos
 		},
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbum, TestImagesPathHelper.ArchiveFolder(), 3, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbumId, TestImagesPathHelper.ArchiveFolder(), 3, rawOutput: true),
 			MergeList(ItalyArezzoPhotos, ItalyFirenzePhotos)
 		},
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbum, TestImagesPathHelper.ArchiveFolder(), 4, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbumId, TestImagesPathHelper.ArchiveFolder(), 4, rawOutput: true),
 			ItalyArezzoPhotos
 		},
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbum, TestImagesPathHelper.ArchiveFolder(), 16, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbumId, TestImagesPathHelper.ArchiveFolder(), 16, rawOutput: true),
 			ItalyFirenzePhotos
 		},
 	};
@@ -156,7 +156,7 @@ public class ListVerbEndToEndTests : BaseEndToEndTests
 	public static TheoryData<ICollection<string>, string[]> PhotoIdsAlbumPhotosWithExpectedFilePaths = new()
 	{
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbum, TestImagesPathHelper.ArchiveFolder(), 5, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByAlbumId, TestImagesPathHelper.ArchiveFolder(), 5, rawOutput: true),
 			MergeList(SpainPhotosWithPhotoTakenDate, SpainPhotosWitNoPhotoTakenDate)
 		},
 	};
@@ -179,11 +179,11 @@ public class ListVerbEndToEndTests : BaseEndToEndTests
 	public static TheoryData<ICollection<string>, string[]> YearPhotosWithExpectedFilePaths = new()
 	{
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDate, TestImagesPathHelper.ArchiveFolder(), year: 2015, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByExactDate, TestImagesPathHelper.ArchiveFolder(), year: 2015, rawOutput: true),
 			SpainPhotosWithPhotoTakenDate
 		},
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDate, TestImagesPathHelper.ArchiveFolder(), year: 2005, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByExactDate, TestImagesPathHelper.ArchiveFolder(), year: 2005, rawOutput: true),
 			MergeList(KenyaPhotos, ItalyFirenzePhotos)
 		}
 	};
@@ -191,11 +191,11 @@ public class ListVerbEndToEndTests : BaseEndToEndTests
 	public static TheoryData<ICollection<string>, string[]> YearMonthPhotosWithExpectedFilePaths = new()
 	{
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDate, TestImagesPathHelper.ArchiveFolder(), year: 2008, month: 10, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByExactDate, TestImagesPathHelper.ArchiveFolder(), year: 2008, month: 10, rawOutput: true),
 			ItalyArezzoPhotos
 		},
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDate, TestImagesPathHelper.ArchiveFolder(), year: 2005, month: 8, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByExactDate, TestImagesPathHelper.ArchiveFolder(), year: 2005, month: 8, rawOutput: true),
 			KenyaPhotos
 		}
 	};
@@ -203,11 +203,11 @@ public class ListVerbEndToEndTests : BaseEndToEndTests
 	public static TheoryData<ICollection<string>, string[]> YearMonthDayPhotosWithExpectedFilePaths = new()
 	{
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDate, TestImagesPathHelper.ArchiveFolder(), year: 2008, month: 10, day: 22, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByExactDate, TestImagesPathHelper.ArchiveFolder(), year: 2008, month: 10, day: 22, rawOutput: true),
 			ItalyArezzoPhotos
 		},
 		{
-			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDate, TestImagesPathHelper.ArchiveFolder(), year: 2015, month: 4, day: 10, rawOutput: true),
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByExactDate, TestImagesPathHelper.ArchiveFolder(), year: 2015, month: 4, day: 10, rawOutput: true),
 			SpainPhotosWithPhotoTakenDate
 		}
 	};
@@ -217,6 +217,31 @@ public class ListVerbEndToEndTests : BaseEndToEndTests
 	[MemberData(nameof(YearMonthPhotosWithExpectedFilePaths))]
 	[MemberData(nameof(YearMonthDayPhotosWithExpectedFilePaths))]
 	public async Task Run_WithPhotosByDateCommand_ReturnsExpectedPhotoPaths(ICollection<string> args, string[] expectedPhotoPaths)
+	{
+		await RunAndVerifyOutputPaths(args, expectedPhotoPaths);
+	}
+
+	#endregion
+
+	#region PhotosByDateRange
+
+	public static TheoryData<ICollection<string>, string[]> DateRangePhotosWithExpectedFilePaths = new()
+	{
+		{
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDateRange, TestImagesPathHelper.ArchiveFolder(),
+				startDate: new DateTime(2008, 10, 22, 0, 0, 0), endDate: new DateTime(2008, 10, 22, 23, 59, 59), rawOutput: true),
+			ItalyArezzoPhotos
+		},
+		{
+			CommandLineArgumentsFakes.ListBuildCommandLineOptions(ListType.PhotosByDateRange, TestImagesPathHelper.ArchiveFolder(),
+				startDate: new DateTime(2005, 1, 1), endDate: new DateTime(2005, 12, 31, 23, 59, 59), rawOutput: true),
+			MergeList(KenyaPhotos, ItalyFirenzePhotos)
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(DateRangePhotosWithExpectedFilePaths))]
+	public async Task Run_WithPhotosByDateRangeCommand_ReturnsExpectedPhotoPaths(ICollection<string> args, string[] expectedPhotoPaths)
 	{
 		await RunAndVerifyOutputPaths(args, expectedPhotoPaths);
 	}

--- a/tests/Fakes/CommandLineArgumentsFakes.cs
+++ b/tests/Fakes/CommandLineArgumentsFakes.cs
@@ -199,7 +199,7 @@ public static class CommandLineArgumentsFakes
 	}
 
 	public static ICollection<string> ListBuildCommandLineOptions(ListType listType, string inputPath, int? albumId = null, int? year = null, byte? month = null, byte? day = null,
-		bool rawOutput = false)
+		DateTime? startDate = null, DateTime? endDate = null, bool rawOutput = false)
 	{
 		var args = new List<string> { "list" };
 
@@ -214,6 +214,10 @@ public static class CommandLineArgumentsFakes
 			AddArgumentWithParameter('m', month.Value.ToString(), args);
 		if (day != null)
 			AddArgumentWithParameter('d', day.Value.ToString(), args);
+		if (startDate != null)
+			AddArgumentWithParameter('s', startDate.Value.ToString("yyyy-MM-ddTHH:mm:ss"), args);
+		if (endDate != null)
+			AddArgumentWithParameter('e', endDate.Value.ToString("yyyy-MM-ddTHH:mm:ss"), args);
 		if (rawOutput)
 			AddArgumentWithoutParameter('r', args);
 

--- a/tests/Fakes/Options/ListOptionsFakes.cs
+++ b/tests/Fakes/Options/ListOptionsFakes.cs
@@ -23,9 +23,19 @@ public static class ListOptionsFakes
 	public static ListOptions PhotosByAlbum(int albumId, string? archivePath = null, bool rawOutput = false)
 	{
 		return new ListOptions(
-			listType: ListType.PhotosByAlbum,
+			listType: ListType.PhotosByAlbumId,
 			archivePath: archivePath ?? ArchivePath,
 			albumId: albumId,
+			rawOutput: rawOutput
+		);
+	}
+
+	public static ListOptions PhotosByAlbumName(string albumName, string? archivePath = null, bool rawOutput = false)
+	{
+		return new ListOptions(
+			listType: ListType.PhotosByAlbumName,
+			archivePath: archivePath ?? ArchivePath,
+			albumName: albumName,
 			rawOutput: rawOutput
 		);
 	}
@@ -33,11 +43,22 @@ public static class ListOptionsFakes
 	public static ListOptions PhotosByDate(int? year = null, byte? month = null, byte? day = null, string? archivePath = null, bool rawOutput = false)
 	{
 		return new ListOptions(
-			listType: ListType.PhotosByDate,
+			listType: ListType.PhotosByExactDate,
 			archivePath: archivePath ?? ArchivePath,
 			year: year,
 			month: month,
 			day: day,
+			rawOutput: rawOutput
+		);
+	}
+
+	public static ListOptions PhotosByDateRange(DateTime startDate, DateTime endDate, string? archivePath = null, bool rawOutput = false)
+	{
+		return new ListOptions(
+			listType: ListType.PhotosByDateRange,
+			archivePath: archivePath ?? ArchivePath,
+			startDate: startDate,
+			endDate: endDate,
 			rawOutput: rawOutput
 		);
 	}

--- a/tests/IntegrationTests/DbContext/ListDbServiceIntegrationTests.cs
+++ b/tests/IntegrationTests/DbContext/ListDbServiceIntegrationTests.cs
@@ -218,6 +218,102 @@ public class ListDbServiceIntegrationTests : DbServiceIntegrationTestsBase
 
 	#endregion
 
+	#region GetAlbumPhotosByName
+
+	#region Expected Flows
+
+	public static TheoryData<PhotoEntity[], AlbumEntity[], string, PhotoEntity[]> AlbumWithPhotoIdsConfigurationWithMatchingResultByName = new()
+	{
+		{
+			[
+				PhotoEntityFakes.WithId(1),
+			],
+			[AlbumEntityFakes.WithPhotoIdsAndName("Album A", [1])],
+			"Album A",
+			[
+				PhotoEntityFakes.WithId(1),
+			]
+		},
+		{
+			[
+				PhotoEntityFakes.WithId(2),
+				PhotoEntityFakes.WithId(3),
+				PhotoEntityFakes.WithId(4),
+				PhotoEntityFakes.WithId(5),
+			],
+			[AlbumEntityFakes.WithPhotoIdsAndName("Album B", [3, 4])],
+			"Album B",
+			[
+				PhotoEntityFakes.WithId(3),
+				PhotoEntityFakes.WithId(4),
+			]
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(AlbumWithPhotoIdsConfigurationWithMatchingResultByName))]
+	public async Task GetAlbumPhotosByName_GivenExistingAlbumName_ShouldMatchWithAlbumPhotoResult(PhotoEntity[] existingPhotos, AlbumEntity[] existingAlbums, string albumName,
+		PhotoEntity[] expectedPhotosResult)
+	{
+		var sut = await DbServiceSetupWithPhotosAndAlbums(existingPhotos, existingAlbums);
+		var (actualAlbumPhotoResultStatus, actualPhotosResult) = await sut.GetAlbumPhotosByName(albumName);
+
+		using (new AssertionScope())
+		{
+			actualAlbumPhotoResultStatus.Should().Be(AlbumPhotoResultStatus.Successful);
+
+			actualPhotosResult.Should().BeEquivalentTo(expectedPhotosResult, c => c
+				.Excluding(e => e.Id)
+			);
+		}
+	}
+
+	#endregion
+
+	#region Breaking Flows
+
+	public static TheoryData<AlbumEntity[], string> NonExistingAlbumNameTestData = new()
+	{
+		{
+			[],
+			"Ghost Album"
+		},
+		{
+			[AlbumEntityFakes.WithPhotoIdsAndName("Existing Album", [1])],
+			"Other Album"
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(NonExistingAlbumNameTestData))]
+	public async Task GetAlbumPhotosByName_GivenNotExistingAlbumName_ShouldReturnResultOfAlbumNotFound(AlbumEntity[] existingAlbums, string albumName)
+	{
+		var sut = await DbServiceSetupWithAlbums(existingAlbums);
+		var actualAlbumPhotoResult = await sut.GetAlbumPhotosByName(albumName);
+		actualAlbumPhotoResult.Should().BeEquivalentTo(new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, []));
+	}
+
+	public static TheoryData<AlbumEntity[], string> MisconfiguredAlbumNameTestData = new()
+	{
+		{
+			[AlbumEntityFakes.WithRawConfiguration("{")],
+			AlbumNameFakes.Valid()
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(MisconfiguredAlbumNameTestData))]
+	public async Task GetAlbumPhotosByName_GivenMisconfiguredAlbumName_ShouldReturnResultOfExistingConfigurationNotInCorrectFormat(AlbumEntity[] existingAlbums, string albumName)
+	{
+		var sut = await DbServiceSetupWithAlbums(existingAlbums);
+		var actualAlbumPhotoResult = await sut.GetAlbumPhotosByName(albumName);
+		actualAlbumPhotoResult.Should().BeEquivalentTo(new AlbumPhotoResult(AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat, []));
+	}
+
+	#endregion
+
+	#endregion
+
 	#region GetPhotosByDate
 
 	public static TheoryData<PhotoEntity[], int?, byte?, byte?, PhotoEntity[]> PhotosWithYearMatching = new()
@@ -297,6 +393,56 @@ public class ListDbServiceIntegrationTests : DbServiceIntegrationTestsBase
 	{
 		var sut = await DbServiceSetupWithPhotos(existingPhotos);
 		var actualPhotosResult = await sut.GetPhotosByDate(yearRequested, monthRequested, dayRequested);
+
+		actualPhotosResult.Should().BeEquivalentTo(expectedPhotosResult);
+	}
+
+	#endregion
+
+	#region GetPhotosByDateRange
+
+	public static TheoryData<PhotoEntity[], DateTime, DateTime, PhotoEntity[]> PhotosWithDateRangeMatching = new()
+	{
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 17, 10, 0, 0), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 18, 10, 0, 0), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 19, 10, 0, 0), 3),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 20, 10, 0, 0), 4),
+			],
+			new DateTime(2020, 3, 17), new DateTime(2020, 3, 19),
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 17, 10, 0, 0), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 18, 10, 0, 0), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 19, 10, 0, 0), 3),
+			]
+		},
+	};
+
+	public static TheoryData<PhotoEntity[], DateTime, DateTime, PhotoEntity[]> PhotosWithDateRangeExcludesDeleted = new()
+	{
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 3, 17, 10, 0, 0), 1, false),
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 3, 17, 10, 0, 0), 2, true),
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 3, 18, 10, 0, 0), 3, false),
+			],
+			new DateTime(2020, 3, 17), new DateTime(2020, 3, 18),
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 3, 17, 10, 0, 0), 1, false),
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 3, 18, 10, 0, 0), 3, false),
+			]
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(PhotosWithDateRangeMatching))]
+	[MemberData(nameof(PhotosWithDateRangeExcludesDeleted))]
+	public async Task GetPhotosByDateRange_GivenDateRangeParameters_ShouldReturnMatchingPhotos(PhotoEntity[] existingPhotos, DateTime start, DateTime end,
+		PhotoEntity[] expectedPhotosResult)
+	{
+		var sut = await DbServiceSetupWithPhotos(existingPhotos);
+		var actualPhotosResult = await sut.GetPhotosByDateRange(start, end);
 
 		actualPhotosResult.Should().BeEquivalentTo(expectedPhotosResult);
 	}

--- a/tests/IntegrationTests/DbContext/McpDbServiceIntegrationTests.cs
+++ b/tests/IntegrationTests/DbContext/McpDbServiceIntegrationTests.cs
@@ -1,0 +1,416 @@
+namespace PhotoCli.Tests.IntegrationTests.DbContext;
+
+public class McpDbServiceIntegrationTests : DbServiceIntegrationTestsBase
+{
+	#region SearchPhotos
+
+	#region Expected Flows
+
+	public static TheoryData<PhotoEntity[], DateTime?, DateTime?, int, PhotoEntity[]> SearchPhotosWithDateFilters = new()
+	{
+		// Start date filter - returns photos on or after start date, ordered by date desc
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 1, 1), 3),
+			],
+			new DateTime(2020, 6, 1), null, 100,
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 1, 1), 3),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+			]
+		},
+		// End date filter - returns photos on or before end date, ordered by date desc
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 1, 1), 3),
+			],
+			null, new DateTime(2020, 6, 1), 100,
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+			]
+		},
+		// Date range filter
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 1, 1), 3),
+			],
+			new DateTime(2020, 3, 1), new DateTime(2020, 8, 1), 100,
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+			]
+		},
+		// Limit applied - returns most recent photos up to limit
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 1, 1), 3),
+			],
+			null, null, 2,
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 1, 1), 3),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 1), 2),
+			]
+		},
+		// Deleted photos excluded
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 1, 1), 1, false),
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 6, 1), 2, true),
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2021, 1, 1), 3, false),
+			],
+			null, null, 100,
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2021, 1, 1), 3, false),
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(new DateTime(2020, 1, 1), 1, false),
+			]
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(SearchPhotosWithDateFilters))]
+	public async Task SearchPhotos_GivenDateFilters_ShouldReturnMatchingPhotosOrderedByDateDesc(
+		PhotoEntity[] existingPhotos, DateTime? start, DateTime? end, int limit, PhotoEntity[] expectedPhotos)
+	{
+		var sut = await DbServiceSetupWithPhotos(existingPhotos);
+		var actualPhotos = await sut.SearchPhotos(start, end, null, limit);
+		actualPhotos.Should().BeEquivalentTo(expectedPhotos, c => c.WithStrictOrdering());
+	}
+
+	public static TheoryData<PhotoEntity[], string, PhotoEntity[]> SearchPhotosWithLocationFilter = new()
+	{
+		{
+			[
+				WithReverseGeocodeFormattedAndId("Paris, France", 1),
+				WithReverseGeocodeFormattedAndId("London, UK", 2),
+				WithReverseGeocodeFormattedAndId(null, 3),
+			],
+			"Paris",
+			[
+				WithReverseGeocodeFormattedAndId("Paris, France", 1),
+			]
+		},
+		{
+			[
+				WithReverseGeocodeFormattedAndId("Paris, France", 1),
+				WithReverseGeocodeFormattedAndId("London, UK", 2),
+				WithReverseGeocodeFormattedAndId("New York, USA", 3),
+			],
+			"UK",
+			[
+				WithReverseGeocodeFormattedAndId("London, UK", 2),
+			]
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(SearchPhotosWithLocationFilter))]
+	public async Task SearchPhotos_GivenLocationFilter_ShouldReturnPhotosMatchingLocation(
+		PhotoEntity[] existingPhotos, string location, PhotoEntity[] expectedPhotos)
+	{
+		var sut = await DbServiceSetupWithPhotos(existingPhotos);
+		var actualPhotos = await sut.SearchPhotos(null, null, location, 100);
+		actualPhotos.Should().BeEquivalentTo(expectedPhotos);
+	}
+
+	#endregion
+
+	#endregion
+
+	#region GetPhotoByPath
+
+	#region Expected Flows
+
+	public static TheoryData<PhotoEntity[], string, PhotoEntity?> GetPhotoByPathTestData = new()
+	{
+		// Existing path returns matching photo
+		{
+			[PhotoEntityFakes.CreateWithExifData(path: "photos/vacation.jpg")],
+			"photos/vacation.jpg",
+			PhotoEntityFakes.CreateWithExifData(path: "photos/vacation.jpg")
+		},
+		// Non-existing path returns null
+		{
+			[PhotoEntityFakes.CreateWithExifData(path: "photos/vacation.jpg")],
+			"photos/other.jpg",
+			null
+		},
+		// Empty database returns null
+		{
+			[],
+			"photos/any.jpg",
+			null
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(GetPhotoByPathTestData))]
+	public async Task GetPhotoByPath_GivenPath_ShouldReturnMatchingPhoto(
+		PhotoEntity[] existingPhotos, string path, PhotoEntity? expectedPhoto)
+	{
+		var sut = await DbServiceSetupWithPhotos(existingPhotos);
+		var actualPhoto = await sut.GetPhotoByPath(path);
+		actualPhoto.Should().BeEquivalentTo(expectedPhoto, c => c.Excluding(e => e!.Id));
+	}
+
+	#endregion
+
+	#region Breaking Flows
+
+	[Fact]
+	public async Task GetPhotoByPath_DeletedPhoto_ShouldReturnNull()
+	{
+		var deletedPhoto = PhotoEntityFakes.CreateWithExifData(path: "photos/deleted.jpg") with { IsDeleted = true };
+		var sut = await DbServiceSetupWithPhotos([deletedPhoto]);
+		var actualPhoto = await sut.GetPhotoByPath("photos/deleted.jpg");
+		actualPhoto.Should().BeNull();
+	}
+
+	#endregion
+
+	#endregion
+
+	#region GetPhotoStatistics
+
+	#region Expected Flows
+
+	public static TheoryData<PhotoEntity[], string, List<PhotoStatisticsRow>> GetPhotoStatisticsGroupByYear = new()
+	{
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithYear(2020), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithYear(2020), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithYear(2021), 3),
+			],
+			"year",
+			[new PhotoStatisticsRow(2020, null, null, 2), new PhotoStatisticsRow(2021, null, null, 1)]
+		},
+		// Deleted photos excluded from year grouping
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithYear(2020), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndIdAdIsDeleted(DateTimeFakes.WithYear(2020), 2, true),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithYear(2021), 3),
+			],
+			"year",
+			[new PhotoStatisticsRow(2020, null, null, 1), new PhotoStatisticsRow(2021, null, null, 1)]
+		},
+	};
+
+	public static TheoryData<PhotoEntity[], string, List<PhotoStatisticsRow>> GetPhotoStatisticsGroupByMonth = new()
+	{
+		{
+			[
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithMonth(1), 1),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithMonth(1), 2),
+				PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithMonth(3), 3),
+			],
+			"month",
+			[
+				new PhotoStatisticsRow(DateTimeFakes.WithMonth(1).Year, 1, null, 2),
+				new PhotoStatisticsRow(DateTimeFakes.WithMonth(3).Year, 3, null, 1),
+			]
+		},
+	};
+
+	public static TheoryData<PhotoEntity[], string, List<PhotoStatisticsRow>> GetPhotoStatisticsGroupByLocation = new()
+	{
+		// "location" groupBy uses Address1, ordered by count desc
+		{
+			[
+				CreateWithAddress1AndId("City1", 1),
+				CreateWithAddress1AndId("City2", 2),
+				CreateWithAddress1AndId("City2", 3),
+				CreateWithAddress1AndId("City2", 4),
+			],
+			"location",
+			[
+				new PhotoStatisticsRow(null, null, "City2", 3),
+				new PhotoStatisticsRow(null, null, "City1", 1),
+			]
+		},
+		// "address1" is alias for "location"
+		{
+			[
+				CreateWithAddress1AndId("Paris", 1),
+				CreateWithAddress1AndId("Paris", 2),
+				CreateWithAddress1AndId("London", 3),
+			],
+			"address1",
+			[
+				new PhotoStatisticsRow(null, null, "Paris", 2),
+				new PhotoStatisticsRow(null, null, "London", 1),
+			]
+		},
+		// Deleted photos excluded from location grouping
+		{
+			[
+				CreateWithAddress1AndId("City1", 1),
+				(CreateWithAddress1AndId("City1", 2)) with { IsDeleted = true },
+				CreateWithAddress1AndId("City2", 3),
+			],
+			"location",
+			[
+				new PhotoStatisticsRow(null, null, "City1", 1),
+				new PhotoStatisticsRow(null, null, "City2", 1),
+			]
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(GetPhotoStatisticsGroupByYear))]
+	[MemberData(nameof(GetPhotoStatisticsGroupByMonth))]
+	public async Task GetPhotoStatistics_GivenGroupByYearOrMonth_ShouldReturnOrderedStatisticsRows(
+		PhotoEntity[] existingPhotos, string groupBy, List<PhotoStatisticsRow> expectedRows)
+	{
+		var sut = await DbServiceSetupWithPhotos(existingPhotos);
+		var actualRows = await sut.GetPhotoStatistics(groupBy);
+		actualRows.Should().BeEquivalentTo(expectedRows, c => c.WithStrictOrdering());
+	}
+
+	[Theory]
+	[MemberData(nameof(GetPhotoStatisticsGroupByLocation))]
+	public async Task GetPhotoStatistics_GivenLocationGroupBy_ShouldReturnPhotosGroupedByAddressOrderedByCountDesc(
+		PhotoEntity[] existingPhotos, string groupBy, List<PhotoStatisticsRow> expectedRows)
+	{
+		var sut = await DbServiceSetupWithPhotos(existingPhotos);
+		var actualRows = await sut.GetPhotoStatistics(groupBy);
+		actualRows.Should().BeEquivalentTo(expectedRows, c => c.WithStrictOrdering());
+	}
+
+	#endregion
+
+	#region Breaking Flows
+
+	public static TheoryData<string> UnknownGroupByValues = new()
+	{
+		{ "unknown" },
+		{ "invalid" },
+		{ "week" },
+	};
+
+	[Theory]
+	[MemberData(nameof(UnknownGroupByValues))]
+	public async Task GetPhotoStatistics_GivenUnknownGroupBy_ShouldReturnEmptyList(string groupBy)
+	{
+		var sut = await DbServiceSetupWithPhotos([PhotoEntityFakes.WithPhotoTakenDateAndId(DateTimeFakes.WithYear(2020), 1)]);
+		var actualRows = await sut.GetPhotoStatistics(groupBy);
+		actualRows.Should().BeEmpty();
+	}
+
+	#endregion
+
+	#endregion
+
+	#region FindPhotosNearLocation
+
+	#region Expected Flows
+
+	[Fact]
+	public async Task FindPhotosNearLocation_PhotosWithinRadius_ShouldBeReturned()
+	{
+		var nearPhoto = CreateWithCoordinateAndId(40.0, 30.0, 1);
+		var farPhoto = CreateWithCoordinateAndId(0.0, 0.0, 2); // ~5000 km away
+		var sut = await DbServiceSetupWithPhotos([nearPhoto, farPhoto]);
+
+		var results = await sut.FindPhotosNearLocation(40.0, 30.0, 1000.0, 10);
+
+		results.Should().ContainSingle().Which.Path.Should().Be("1.jpg");
+	}
+
+	[Fact]
+	public async Task FindPhotosNearLocation_ResultsOrderedByDistanceAscending()
+	{
+		var closestPhoto = CreateWithCoordinateAndId(40.0, 30.0, 1);
+		var midPhoto = CreateWithCoordinateAndId(40.5, 30.0, 2);
+		var farthestPhoto = CreateWithCoordinateAndId(41.0, 30.0, 3);
+		var sut = await DbServiceSetupWithPhotos([farthestPhoto, midPhoto, closestPhoto]);
+
+		var results = await sut.FindPhotosNearLocation(40.0, 30.0, 500.0, 10);
+
+		results.Should().HaveCount(3);
+		results.Select(r => r.Path).Should().Equal("1.jpg", "2.jpg", "3.jpg");
+		results.Select(r => r.DistanceKm).Should().BeInAscendingOrder();
+	}
+
+	[Fact]
+	public async Task FindPhotosNearLocation_WithLimit_ShouldReturnClosestPhotosUpToLimit()
+	{
+		var closestPhoto = CreateWithCoordinateAndId(40.0, 30.0, 1);
+		var midPhoto = CreateWithCoordinateAndId(40.5, 30.0, 2);
+		var farthestPhoto = CreateWithCoordinateAndId(41.0, 30.0, 3);
+		var sut = await DbServiceSetupWithPhotos([closestPhoto, midPhoto, farthestPhoto]);
+
+		var results = await sut.FindPhotosNearLocation(40.0, 30.0, 500.0, 2);
+
+		results.Should().HaveCount(2);
+		results.Select(r => r.Path).Should().Equal("1.jpg", "2.jpg");
+	}
+
+	#endregion
+
+	#region Breaking Flows
+
+	[Fact]
+	public async Task FindPhotosNearLocation_DeletedPhotos_ShouldBeExcluded()
+	{
+		var activePhoto = CreateWithCoordinateAndId(40.0, 30.0, 1);
+		var deletedPhoto = CreateWithCoordinateAndId(40.0, 30.0, 2) with { IsDeleted = true };
+		var sut = await DbServiceSetupWithPhotos([activePhoto, deletedPhoto]);
+
+		var results = await sut.FindPhotosNearLocation(40.0, 30.0, 100.0, 10);
+
+		results.Should().ContainSingle().Which.Path.Should().Be("1.jpg");
+	}
+
+	[Fact]
+	public async Task FindPhotosNearLocation_PhotosWithoutCoordinates_ShouldBeExcluded()
+	{
+		var photoWithCoordinate = CreateWithCoordinateAndId(40.0, 30.0, 1);
+		var photoWithoutCoordinate = PhotoEntityFakes.WithId(2);
+		var sut = await DbServiceSetupWithPhotos([photoWithCoordinate, photoWithoutCoordinate]);
+
+		var results = await sut.FindPhotosNearLocation(40.0, 30.0, 1000.0, 10);
+
+		results.Should().ContainSingle().Which.Path.Should().Be("1.jpg");
+	}
+
+	#endregion
+
+	#endregion
+
+	#region Helpers
+
+	private static PhotoEntity WithReverseGeocodeFormattedAndId(string? reverseGeocodeFormatted, long id)
+	{
+		return PhotoEntityFakes.CreateWithExifData(id: id) with { ReverseGeocodeFormatted = reverseGeocodeFormatted };
+	}
+
+	private static PhotoEntity CreateWithAddress1AndId(string address1, long id)
+	{
+		return PhotoEntityFakes.CreateWithExifData(exifData: ExifDataFakes.WithReverseGeocodes([address1]), id: id);
+	}
+
+	private static PhotoEntity CreateWithCoordinateAndId(double latitude, double longitude, long id)
+	{
+		return PhotoEntityFakes.CreateWithExifData(exifData: ExifDataFakes.WithCoordinate(new Coordinate(latitude, longitude)), id: id);
+	}
+
+	private static async Task<DbService> DbServiceSetupWithPhotos(PhotoEntity[] existingPhotos)
+	{
+		var (dbService, archiveDbContextProvider) = DbServiceSetup();
+		var archiveDbContext = archiveDbContextProvider.CreateOrGetInstance();
+		await archiveDbContext.Photos.AddRangeAsync(existingPhotos);
+		await archiveDbContext.SaveChangesAsync();
+		return dbService;
+	}
+
+	#endregion
+}

--- a/tests/UnitTests/ArchiveMcpToolsUnitTests.cs
+++ b/tests/UnitTests/ArchiveMcpToolsUnitTests.cs
@@ -1,0 +1,351 @@
+using PhotoCli.McpTools;
+
+namespace PhotoCli.Tests.UnitTests;
+
+public class ArchiveMcpToolsUnitTests
+{
+	private readonly Mock<IDbService> _dbServiceMock = new(MockBehavior.Strict);
+	private readonly Mock<IProcessLauncher> _processLauncherMock = new(MockBehavior.Strict);
+	private readonly McpOptions _mcpOptions = new("/archive");
+
+	private ArchiveMcpTools Sut => new(_dbServiceMock.Object, _processLauncherMock.Object, _mcpOptions);
+
+	#region ListPhotosByAlbumId
+
+	[Fact]
+	public async Task ListPhotosByAlbumId_GivenExistingAlbumId_ShouldReturnSerializedPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 15), 1),
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 3, 10), 2),
+		};
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosById(1))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.Successful, photos));
+
+		var result = await Sut.ListPhotosByAlbumId(1);
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().HaveCount(2);
+		deserialized![0].GetProperty("Path").GetString().Should().Be("1.jpg");
+		deserialized[1].GetProperty("Path").GetString().Should().Be("2.jpg");
+	}
+
+	[Fact]
+	public async Task ListPhotosByAlbumId_GivenNonExistingAlbumId_ShouldReturnNotFoundMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosById(99))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, []));
+
+		var result = await Sut.ListPhotosByAlbumId(99);
+
+		result.Should().Be("Album with id 99 not found.");
+	}
+
+	[Fact]
+	public async Task ListPhotosByAlbumId_GivenInvalidConfiguration_ShouldReturnInvalidConfigurationMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosById(5))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat, []));
+
+		var result = await Sut.ListPhotosByAlbumId(5);
+
+		result.Should().Be("Album with id 5 has invalid configuration.");
+	}
+
+	#endregion
+
+	#region ListPhotosByAlbumName
+
+	[Fact]
+	public async Task ListPhotosByAlbumName_GivenExistingAlbumName_ShouldReturnSerializedPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 15), 1),
+		};
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName("Vacation"))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.Successful, photos));
+
+		var result = await Sut.ListPhotosByAlbumName("Vacation");
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().HaveCount(1);
+		deserialized![0].GetProperty("Path").GetString().Should().Be("1.jpg");
+	}
+
+	[Fact]
+	public async Task ListPhotosByAlbumName_GivenNonExistingAlbumName_ShouldReturnNotFoundMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName("Ghost"))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, []));
+
+		var result = await Sut.ListPhotosByAlbumName("Ghost");
+
+		result.Should().Be("Album with name 'Ghost' not found.");
+	}
+
+	[Fact]
+	public async Task ListPhotosByAlbumName_GivenInvalidConfiguration_ShouldReturnInvalidConfigurationMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName("Broken"))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat, []));
+
+		var result = await Sut.ListPhotosByAlbumName("Broken");
+
+		result.Should().Be("Album with name 'Broken' has invalid configuration.");
+	}
+
+	#endregion
+
+	#region ListPhotosByExactDate
+
+	[Fact]
+	public async Task ListPhotosByExactDate_GivenYearOnly_ShouldReturnMatchingPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 15), 2),
+		};
+		_dbServiceMock.Setup(s => s.GetPhotosByDate(2020, null, null)).ReturnsAsync(photos);
+
+		var result = await Sut.ListPhotosByExactDate(2020);
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task ListPhotosByExactDate_GivenYearMonthDay_ShouldReturnMatchingPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 17), 1),
+		};
+		_dbServiceMock.Setup(s => s.GetPhotosByDate(2020, 3, 17)).ReturnsAsync(photos);
+
+		var result = await Sut.ListPhotosByExactDate(2020, 3, 17);
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().HaveCount(1);
+		deserialized![0].GetProperty("Path").GetString().Should().Be("1.jpg");
+	}
+
+	[Fact]
+	public async Task ListPhotosByExactDate_GivenNoMatches_ShouldReturnEmptyArray()
+	{
+		_dbServiceMock.Setup(s => s.GetPhotosByDate(1999, null, null)).ReturnsAsync([]);
+
+		var result = await Sut.ListPhotosByExactDate(1999);
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().BeEmpty();
+	}
+
+	#endregion
+
+	#region ListPhotosByDateRange
+
+	[Fact]
+	public async Task ListPhotosByDateRange_GivenStartAndEndDate_ShouldReturnMatchingPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 17), 1),
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 18), 2),
+		};
+		_dbServiceMock.Setup(s => s.GetPhotosByDateRange(
+			It.Is<DateTime?>(d => d!.Value.Date == new DateTime(2020, 3, 17)),
+			It.Is<DateTime?>(d => d!.Value.Date == new DateTime(2020, 3, 19))))
+			.ReturnsAsync(photos);
+
+		var result = await Sut.ListPhotosByDateRange("2020-03-17", "2020-03-19");
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().HaveCount(2);
+	}
+
+	[Fact]
+	public async Task ListPhotosByDateRange_GivenNoDates_ShouldReturnAllPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+		};
+		_dbServiceMock.Setup(s => s.GetPhotosByDateRange(null, null)).ReturnsAsync(photos);
+
+		var result = await Sut.ListPhotosByDateRange();
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().HaveCount(1);
+	}
+
+	[Fact]
+	public async Task ListPhotosByDateRange_GivenInvalidDateFormat_ShouldTreatAsNull()
+	{
+		_dbServiceMock.Setup(s => s.GetPhotosByDateRange(null, null)).ReturnsAsync([]);
+
+		var result = await Sut.ListPhotosByDateRange("not-a-date", "also-not-a-date");
+
+		var deserialized = JsonSerializer.Deserialize<JsonElement[]>(result);
+		deserialized.Should().BeEmpty();
+	}
+
+	#endregion
+
+	#region OpenPhotosByAlbumId
+
+	[Fact]
+	public async Task OpenPhotosByAlbumId_GivenExistingAlbumId_ShouldOpenPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 15), 1),
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2021, 3, 10), 2),
+		};
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosById(1))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.Successful, photos));
+		_processLauncherMock.Setup(s => s.Launch(It.IsAny<List<string>>())).Returns(Task.CompletedTask);
+
+		var result = await Sut.OpenPhotosByAlbumId(1);
+
+		result.Should().Be("Opened 2 photo(s) in the default viewer.");
+		_processLauncherMock.Verify(s => s.Launch(It.Is<List<string>>(paths =>
+			paths.Count == 2 &&
+			paths[0] == Path.Combine("/archive", "1.jpg") &&
+			paths[1] == Path.Combine("/archive", "2.jpg"))), Times.Once);
+	}
+
+	[Fact]
+	public async Task OpenPhotosByAlbumId_GivenNonExistingAlbumId_ShouldReturnNotFoundMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosById(99))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, []));
+
+		var result = await Sut.OpenPhotosByAlbumId(99);
+
+		result.Should().Be("Album with id 99 not found.");
+	}
+
+	[Fact]
+	public async Task OpenPhotosByAlbumId_GivenInvalidConfiguration_ShouldReturnInvalidConfigurationMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosById(5))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat, []));
+
+		var result = await Sut.OpenPhotosByAlbumId(5);
+
+		result.Should().Be("Album with id 5 has invalid configuration.");
+	}
+
+	#endregion
+
+	#region OpenPhotosByAlbumName
+
+	[Fact]
+	public async Task OpenPhotosByAlbumName_GivenExistingAlbumName_ShouldOpenPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 15), 1),
+		};
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName("Vacation"))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.Successful, photos));
+		_processLauncherMock.Setup(s => s.Launch(It.IsAny<List<string>>())).Returns(Task.CompletedTask);
+
+		var result = await Sut.OpenPhotosByAlbumName("Vacation");
+
+		result.Should().Be("Opened 1 photo(s) in the default viewer.");
+		_processLauncherMock.Verify(s => s.Launch(It.Is<List<string>>(paths =>
+			paths.Count == 1 &&
+			paths[0] == Path.Combine("/archive", "1.jpg"))), Times.Once);
+	}
+
+	[Fact]
+	public async Task OpenPhotosByAlbumName_GivenNonExistingAlbumName_ShouldReturnNotFoundMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName("Ghost"))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, []));
+
+		var result = await Sut.OpenPhotosByAlbumName("Ghost");
+
+		result.Should().Be("Album with name 'Ghost' not found.");
+	}
+
+	[Fact]
+	public async Task OpenPhotosByAlbumName_GivenInvalidConfiguration_ShouldReturnInvalidConfigurationMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName("Broken"))
+			.ReturnsAsync(new AlbumPhotoResult(AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat, []));
+
+		var result = await Sut.OpenPhotosByAlbumName("Broken");
+
+		result.Should().Be("Album with name 'Broken' has invalid configuration.");
+	}
+
+	#endregion
+
+	#region OpenPhotosByExactDate
+
+	[Fact]
+	public async Task OpenPhotosByExactDate_GivenYearOnly_ShouldOpenMatchingPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 1, 1), 1),
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 6, 15), 2),
+		};
+		_dbServiceMock.Setup(s => s.GetPhotosByDate(2020, null, null)).ReturnsAsync(photos);
+		_processLauncherMock.Setup(s => s.Launch(It.IsAny<List<string>>())).Returns(Task.CompletedTask);
+
+		var result = await Sut.OpenPhotosByExactDate(2020);
+
+		result.Should().Be("Opened 2 photo(s) in the default viewer.");
+	}
+
+	[Fact]
+	public async Task OpenPhotosByExactDate_GivenNoMatches_ShouldReturnNoPhotosMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetPhotosByDate(1999, null, null)).ReturnsAsync([]);
+
+		var result = await Sut.OpenPhotosByExactDate(1999);
+
+		result.Should().Be("No photos found to open.");
+	}
+
+	#endregion
+
+	#region OpenPhotosByDateRange
+
+	[Fact]
+	public async Task OpenPhotosByDateRange_GivenStartAndEndDate_ShouldOpenMatchingPhotos()
+	{
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 17), 1),
+			PhotoEntityFakes.WithPhotoTakenDateAndId(new DateTime(2020, 3, 18), 2),
+		};
+		_dbServiceMock.Setup(s => s.GetPhotosByDateRange(
+			It.Is<DateTime?>(d => d!.Value.Date == new DateTime(2020, 3, 17)),
+			It.Is<DateTime?>(d => d!.Value.Date == new DateTime(2020, 3, 19))))
+			.ReturnsAsync(photos);
+		_processLauncherMock.Setup(s => s.Launch(It.IsAny<List<string>>())).Returns(Task.CompletedTask);
+
+		var result = await Sut.OpenPhotosByDateRange("2020-03-17", "2020-03-19");
+
+		result.Should().Be("Opened 2 photo(s) in the default viewer.");
+	}
+
+	[Fact]
+	public async Task OpenPhotosByDateRange_GivenNoDates_AndNoPhotos_ShouldReturnNoPhotosMessage()
+	{
+		_dbServiceMock.Setup(s => s.GetPhotosByDateRange(null, null)).ReturnsAsync([]);
+
+		var result = await Sut.OpenPhotosByDateRange();
+
+		result.Should().Be("No photos found to open.");
+	}
+
+	#endregion
+}

--- a/tests/UnitTests/ListRunnerUnitTests.cs
+++ b/tests/UnitTests/ListRunnerUnitTests.cs
@@ -85,6 +85,35 @@ public class ListRunnerUnitTests
 		VerifyNoOtherCalls();
 	}
 
+	[Fact]
+	public async Task Execute_PhotosByAlbumNameValidWorkflow_ShouldExitWithSuccessWithVerifyingAllMockedServices()
+	{
+		const string albumName = "My Album";
+		var options = ListOptionsFakes.PhotosByAlbumName(albumName, ArchivePath);
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.Sample(1),
+			PhotoEntityFakes.Sample(2),
+		};
+		var albumPhotoResult = new AlbumPhotoResult(AlbumPhotoResultStatus.Successful, photos);
+
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName(albumName)).ReturnsAsync(albumPhotoResult);
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			_processLauncherMock.Setup(s => s.Launch(It.IsAny<IEnumerable<string>>())).Returns(Task.CompletedTask);
+
+		var sut = Initialize(options);
+		var exitCode = await sut.Execute();
+
+		exitCode.Should().Be(ExitCode.Success);
+		_dbServiceMock.Verify(v => v.GetAlbumPhotosByName(albumName), Times.Once);
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			_processLauncherMock.Verify(v => v.Launch(It.Is<IEnumerable<string>>(paths => paths.Count() == 2)), Times.Once);
+
+		VerifyNoOtherCalls();
+	}
+
 	public static TheoryData<int?, byte?, byte?> PhotoByDateYearMonthDays = new()
 	{
 		{ 2000, null, null },
@@ -197,16 +226,96 @@ public class ListRunnerUnitTests
 		VerifyNoOtherCalls();
 	}
 
+	[Fact]
+	public async Task Execute_PhotosByAlbumNameWithAlbumNotFound_ShouldReturnAlbumNotFoundByName()
+	{
+		const string albumName = "My Album";
+		var options = ListOptionsFakes.PhotosByAlbumName(albumName, ArchivePath);
+		var albumPhotoResult = new AlbumPhotoResult(AlbumPhotoResultStatus.AlbumNotFound, new List<PhotoEntity>());
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName(albumName)).ReturnsAsync(albumPhotoResult);
+
+		var sut = Initialize(options);
+		var exitCode = await sut.Execute();
+
+		exitCode.Should().Be(ExitCode.AlbumNotFoundByName);
+		_dbServiceMock.Verify(v => v.GetAlbumPhotosByName(albumName), Times.Once);
+		VerifyNoOtherCalls();
+	}
+
+	[Fact]
+	public async Task Execute_PhotosByAlbumNameWithInvalidConfiguration_ShouldReturnExistingAlbumConfigurationNotValid()
+	{
+		const string albumName = "My Album";
+		var options = ListOptionsFakes.PhotosByAlbumName(albumName, ArchivePath);
+		var albumPhotoResult = new AlbumPhotoResult(AlbumPhotoResultStatus.ExistingConfigurationNotInCorrectFormat, new List<PhotoEntity>());
+		_dbServiceMock.Setup(s => s.GetAlbumPhotosByName(albumName)).ReturnsAsync(albumPhotoResult);
+
+		var sut = Initialize(options);
+		var exitCode = await sut.Execute();
+
+		exitCode.Should().Be(ExitCode.ExistingAlbumConfigurationNotValid);
+		_dbServiceMock.Verify(v => v.GetAlbumPhotosByName(albumName), Times.Once);
+		VerifyNoOtherCalls();
+	}
+
 	#endregion
 
 	#region Archive Database Not Found
+
+	[Fact]
+	public async Task Execute_PhotosByDateRangeValidWorkflow_ShouldExitWithSuccessWithVerifyingAllMockedServices()
+	{
+		var startDate = new DateTime(2020, 1, 1);
+		var endDate = new DateTime(2020, 12, 31);
+		var options = ListOptionsFakes.PhotosByDateRange(startDate, endDate, ArchivePath);
+		var photos = new List<PhotoEntity>
+		{
+			PhotoEntityFakes.Sample(1),
+			PhotoEntityFakes.Sample(2),
+		};
+
+		_dbServiceMock.Setup(s => s.GetPhotosByDateRange(startDate, endDate)).ReturnsAsync(photos);
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			_processLauncherMock.Setup(s => s.Launch(It.IsAny<IEnumerable<string>>())).Returns(Task.CompletedTask);
+
+		var sut = Initialize(options);
+		var exitCode = await sut.Execute();
+
+		exitCode.Should().Be(ExitCode.Success);
+		_dbServiceMock.Verify(v => v.GetPhotosByDateRange(startDate, endDate), Times.Once);
+
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			_processLauncherMock.Verify(v => v.Launch(It.IsAny<IEnumerable<string>>()), Times.Once);
+
+		VerifyNoOtherCalls();
+	}
+
+	[Fact]
+	public async Task Execute_PhotosByDateRangeWithNoPhotos_ShouldReturnNoPhotoFoundToList()
+	{
+		var startDate = new DateTime(2020, 1, 1);
+		var endDate = new DateTime(2020, 12, 31);
+		var options = ListOptionsFakes.PhotosByDateRange(startDate, endDate, ArchivePath);
+		_dbServiceMock.Setup(s => s.GetPhotosByDateRange(startDate, endDate)).ReturnsAsync(new List<PhotoEntity>());
+
+		var sut = Initialize(options);
+		var exitCode = await sut.Execute();
+
+		exitCode.Should().Be(ExitCode.NoPhotoFoundToList);
+		_dbServiceMock.Verify(v => v.GetPhotosByDateRange(startDate, endDate), Times.Once);
+		_consoleWriterMock.Verify(v => v.Write(It.Is<string>(s => s.Contains("No photo found"))), Times.Once);
+		VerifyNoOtherCalls();
+	}
 
 	public static TheoryData<ListOptions> ListOptionsAllDifferentTypes = new()
 	{
 		ListOptionsFakes.Summary(ArchivePath),
 		ListOptionsFakes.Albums(ArchivePath),
 		ListOptionsFakes.PhotosByAlbum(1, ArchivePath),
+		ListOptionsFakes.PhotosByAlbumName("My Album", ArchivePath),
 		ListOptionsFakes.PhotosByDate(year: 2020, archivePath: ArchivePath),
+		ListOptionsFakes.PhotosByDateRange(new DateTime(2020, 1, 1), new DateTime(2020, 12, 31), ArchivePath),
 	};
 
 	[Theory]


### PR DESCRIPTION
## Summary
- Add MCP (Model Context Protocol) server support, enabling AI assistants to query photo archives through 14 tools: `search_photos`, `get_photo`, `list_albums`, `get_statistics`, `find_near_location`, and various list/open operations by album, date, and date range
- Extend the `list` command with new options for filtering by exact date and album name
- Improve error handling with exception console output and a new exit code

## Changes
- New `mcp` verb with `ArchiveMcpTools` exposing the archive SQLite database via MCP tool endpoints
- New DB query methods in `DbService` for album listing, date-based filtering, geo-proximity search, and statistics
- Extended `ListOptions`/`ListRunner` to support `ByExactDate` and `ByAlbumName` list types
- Added `NullConsoleWriter` and `McpArchiveDbContextProvider` for MCP server mode
- Comprehensive test coverage: unit tests for MCP tools, integration tests for new DB queries, and updated end-to-end tests